### PR TITLE
Treat "package:" URLs as absolute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.4.2
 
+* Treat `package:` URLs as absolute.
+
 * Normalize `c:\foo\.` to `c:\foo`.
 
 ## 1.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.4.2-dev
+version: 1.4.2
 author: Dart Team <misc@dartlang.org>
 description: >
  A string-based path manipulation library. All of the path operations you know


### PR DESCRIPTION
Closes dart-lang/core#505