### PR TITLE
Drop implementation of `retype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Drop the `retype` implementation for compatibility with the latest SDK.
+
 ## 1.6.0
 
 * Add a `PathMap` class that uses path equality for its keys.

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -73,8 +73,6 @@ class PathSet extends IterableBase<String> implements Set<String> {
 
   void retainAll(Iterable<Object> elements) => _inner.retainAll(elements);
 
-  Set<T> retype<T>() => _inner.retype<T>();
-
   void retainWhere(bool test(String element)) => _inner.retainWhere(test);
 
   Set<String> union(Set<String> other) => _inner.union(other);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.6.0
+version: 1.6.1
 author: Dart Team <misc@dartlang.org>
 description: >
  A string-based path manipulation library. All of the path operations you know
@@ -9,4 +9,4 @@ homepage: http://github.com/dart-lang/path
 dev_dependencies:
   test: ">=0.12.0 <0.13.0"
 environment:
-  sdk: ">=2.0.0-dev.35.0 <2.0.0"
+  sdk: ">=2.0.0-dev.62.0 <2.0.0"


### PR DESCRIPTION
Technically it's possible that there exists a reference using `PathSet`
and calling `retype` but the liklihood is very small and since we're in
the `-dev` versions of the SDK it's not worth marking this a breaking
change.