### PR TITLE
Use backquotes for backslashes to avoid markdown escaping in docs.

### DIFF
--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -13,11 +13,11 @@ abstract class Style {
   /// start with "/". Used by UNIX, Linux, Mac OS X, and others.
   static final Style posix = new PosixStyle();
 
-  /// Windows paths use "\" (backslash) as separators. Absolute paths start with
-  /// a drive letter followed by a colon (example, "C:") or two backslashes
-  /// ("\\") for UNC paths.
+  /// Windows paths use `\` (backslash) as separators. Absolute paths start with
+  /// a drive letter followed by a colon (example, `C:`) or two backslashes
+  /// (`\\`) for UNC paths.
   // TODO(rnystrom): The UNC root prefix should include the drive name too, not
-  // just the "\\".
+  // just the `\\`.
   static final Style windows = new WindowsStyle();
 
   /// URLs aren't filesystem paths, but they're supported to make it easier to


### PR DESCRIPTION
Fixes dart-lang/dartdoc#1364.

Actually, it just implements my suggested workaround; use backquotes to avoid a backslash being interpreted as a markdown escape.

This results in the following rendering:

![screenshot from 2018-08-28 14-20-50](https://user-images.githubusercontent.com/14116827/44751838-0cd3eb80-aace-11e8-8852-6dd5acd49902.png)
