### PR TITLE
Run "dartfmt --fix".

### DIFF
--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -5,7 +5,7 @@
 import 'package:path/path.dart' as p;
 
 /// Some hopefully real-world representative platform-independent paths.
-const genericPaths = const [
+const genericPaths = [
   '.',
   '..',
   'out/ReleaseIA32/packages',
@@ -38,7 +38,7 @@ void main(List<String> args) {
   arguments = args;
 
   for (var style in [p.Style.posix, p.Style.url, p.Style.windows]) {
-    var context = new p.Context(style: style);
+    var context = p.Context(style: style);
     var files = genericPaths.toList()..addAll(platformPaths[style]);
 
     benchmark(String name, Function function) {
@@ -95,7 +95,7 @@ void runBenchmark(String name, int count, Function function) {
     function();
   }
 
-  var stopwatch = new Stopwatch()..start();
+  var stopwatch = Stopwatch()..start();
   for (var i = 0; i < count; i++) {
     function();
   }

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -54,16 +54,16 @@ export 'src/path_set.dart';
 export 'src/style.dart';
 
 /// A default context for manipulating POSIX paths.
-final Context posix = new Context(style: Style.posix);
+final Context posix = Context(style: Style.posix);
 
 /// A default context for manipulating Windows paths.
-final Context windows = new Context(style: Style.windows);
+final Context windows = Context(style: Style.windows);
 
 /// A default context for manipulating URLs.
 ///
 /// URL path equality is undefined for paths that differ only in their
 /// percent-encoding or only in the case of their host segment.
-final Context url = new Context(style: Style.url);
+final Context url = Context(style: Style.url);
 
 /// The system path context.
 ///

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -11,7 +11,7 @@ import 'parsed_path.dart';
 import 'path_exception.dart';
 import '../path.dart' as p;
 
-Context createInternal() => new Context._internal();
+Context createInternal() => Context._internal();
 
 /// An instantiable class for manipulating paths. Unlike the top-level
 /// functions, this lets you explicitly select what platform the paths will use.
@@ -37,11 +37,11 @@ class Context {
     if (style == null) {
       style = Style.platform;
     } else if (style is! InternalStyle) {
-      throw new ArgumentError("Only styles defined by the path package are "
+      throw ArgumentError("Only styles defined by the path package are "
           "allowed.");
     }
 
-    return new Context._(style as InternalStyle, current);
+    return Context._(style as InternalStyle, current);
   }
 
   /// Create a [Context] to be used internally within path.
@@ -247,7 +247,7 @@ class Context {
   ///
   /// For a fixed number of parts, [join] is usually terser.
   String joinAll(Iterable<String> parts) {
-    var buffer = new StringBuffer();
+    var buffer = StringBuffer();
     var needsSeparator = false;
     var isAbsoluteAndNotRootRelative = false;
 
@@ -468,7 +468,7 @@ class Context {
     // If the path is still relative and `from` is absolute, we're unable to
     // find a path from `from` to `path`.
     if (this.isRelative(path) && this.isAbsolute(from)) {
-      throw new PathException('Unable to find a path to "$path" from "$from".');
+      throw PathException('Unable to find a path to "$path" from "$from".');
     }
 
     var fromParsed = _parse(from)..normalize();
@@ -502,13 +502,12 @@ class Context {
     // out of them. If a directory left in the from path is '..', it cannot
     // be cancelled by adding a '..'.
     if (fromParsed.parts.length > 0 && fromParsed.parts[0] == '..') {
-      throw new PathException('Unable to find a path to "$path" from "$from".');
+      throw PathException('Unable to find a path to "$path" from "$from".');
     }
-    pathParsed.parts
-        .insertAll(0, new List.filled(fromParsed.parts.length, '..'));
+    pathParsed.parts.insertAll(0, List.filled(fromParsed.parts.length, '..'));
     pathParsed.separators[0] = '';
-    pathParsed.separators.insertAll(
-        1, new List.filled(fromParsed.parts.length, style.separator));
+    pathParsed.separators
+        .insertAll(1, List.filled(fromParsed.parts.length, style.separator));
 
     // Corner case: the paths completely collapsed.
     if (pathParsed.parts.length == 0) return '.';
@@ -1053,7 +1052,7 @@ class Context {
     return split(rel).length > split(path).length ? path : rel;
   }
 
-  ParsedPath _parse(String path) => new ParsedPath.parse(path, style);
+  ParsedPath _parse(String path) => ParsedPath.parse(path, style);
 }
 
 /// Parses argument if it's a [String] or returns it intact if it's a [Uri].
@@ -1062,7 +1061,7 @@ class Context {
 Uri _parseUri(uri) {
   if (uri is String) return Uri.parse(uri);
   if (uri is Uri) return uri;
-  throw new ArgumentError.value(uri, 'uri', 'Value must be a String or a Uri');
+  throw ArgumentError.value(uri, 'uri', 'Value must be a String or a Uri');
 }
 
 /// Validates that there are no non-null arguments following a null one and
@@ -1078,14 +1077,14 @@ void _validateArgList(String method, List<String> args) {
     }
 
     // Show the arguments.
-    var message = new StringBuffer();
+    var message = StringBuffer();
     message.write("$method(");
     message.write(args
         .take(numArgs)
         .map((arg) => arg == null ? "null" : '"$arg"')
         .join(", "));
     message.write("): part ${i - 1} was null, but part $i was not.");
-    throw new ArgumentError(message.toString());
+    throw ArgumentError(message.toString());
   }
 }
 
@@ -1096,18 +1095,18 @@ class _PathDirection {
   ///
   /// Note that this applies even if the path ends beneath its original root. It
   /// takes precendence over any other return values that may apple.
-  static const aboveRoot = const _PathDirection("above root");
+  static const aboveRoot = _PathDirection("above root");
 
   /// The path contains enough ".." components that it ends at its original
   /// root.
-  static const atRoot = const _PathDirection("at root");
+  static const atRoot = _PathDirection("at root");
 
   /// The path contains enough ".." components that at some point it reaches its
   /// original root, but it ends beneath that root.
-  static const reachesRoot = const _PathDirection("reaches root");
+  static const reachesRoot = _PathDirection("reaches root");
 
   /// The path never reaches to or above its original root.
-  static const belowRoot = const _PathDirection("below root");
+  static const belowRoot = _PathDirection("below root");
 
   final String name;
 
@@ -1121,21 +1120,21 @@ class _PathRelation {
   /// The first path is a proper parent of the second.
   ///
   /// For example, `foo` is a proper parent of `foo/bar`, but not of `foo`.
-  static const within = const _PathRelation("within");
+  static const within = _PathRelation("within");
 
   /// The two paths are equivalent.
   ///
   /// For example, `foo//bar` is equivalent to `foo/bar`.
-  static const equal = const _PathRelation("equal");
+  static const equal = _PathRelation("equal");
 
   /// The first path is neither a parent of nor equal to the second.
-  static const different = const _PathRelation("different");
+  static const different = _PathRelation("different");
 
   /// We couldn't quickly determine any information about the paths'
   /// relationship to each other.
   ///
   /// Only returned by [Context._isWithinOrEqualsFast].
-  static const inconclusive = const _PathRelation("inconclusive");
+  static const inconclusive = _PathRelation("inconclusive");
 
   final String name;
 

--- a/lib/src/internal_style.dart
+++ b/lib/src/internal_style.dart
@@ -37,7 +37,7 @@ abstract class InternalStyle extends Style {
   ///
   /// If [withDrive] is `true`, this should include the drive letter for `file:`
   /// URLs. Non-URL styles may ignore the parameter.
-  int rootLength(String path, {bool withDrive: false});
+  int rootLength(String path, {bool withDrive = false});
 
   /// Gets the root prefix of [path] if path is absolute. If [path] is relative,
   /// returns `null`.
@@ -62,7 +62,7 @@ abstract class InternalStyle extends Style {
     // Ensure that a trailing slash in the path produces a trailing slash in the
     // URL.
     if (isSeparator(path.codeUnitAt(path.length - 1))) segments.add('');
-    return new Uri(pathSegments: segments);
+    return Uri(pathSegments: segments);
   }
 
   /// Returns the URI that represents [path], which is assumed to be absolute.

--- a/lib/src/parsed_path.dart
+++ b/lib/src/parsed_path.dart
@@ -71,7 +71,7 @@ class ParsedPath {
       separators.add('');
     }
 
-    return new ParsedPath._(style, root, isRootRelative, parts, separators);
+    return ParsedPath._(style, root, isRootRelative, parts, separators);
   }
 
   ParsedPath._(
@@ -97,7 +97,7 @@ class ParsedPath {
     if (separators.length > 0) separators[separators.length - 1] = '';
   }
 
-  void normalize({bool canonicalize: false}) {
+  void normalize({bool canonicalize = false}) {
     // Handle '.', '..', and empty parts.
     var leadingDoubles = 0;
     var newParts = <String>[];
@@ -119,7 +119,7 @@ class ParsedPath {
 
     // A relative path can back out from the start directory.
     if (!isAbsolute) {
-      newParts.insertAll(0, new List.filled(leadingDoubles, '..'));
+      newParts.insertAll(0, List.filled(leadingDoubles, '..'));
     }
 
     // If we collapsed down to nothing, do ".".
@@ -128,7 +128,7 @@ class ParsedPath {
     }
 
     // Canonicalize separators.
-    var newSeparators = new List<String>.generate(
+    var newSeparators = List<String>.generate(
         newParts.length, (_) => style.separator,
         growable: true);
     newSeparators.insert(
@@ -149,7 +149,7 @@ class ParsedPath {
   }
 
   String toString() {
-    var builder = new StringBuffer();
+    var builder = StringBuffer();
     if (root != null) builder.write(root);
     for (var i = 0; i < parts.length; i++) {
       builder.write(separators[i]);
@@ -180,6 +180,6 @@ class ParsedPath {
     return [file.substring(0, lastDot), file.substring(lastDot)];
   }
 
-  ParsedPath clone() => new ParsedPath._(style, root, isRootRelative,
-      new List.from(parts), new List.from(separators));
+  ParsedPath clone() => ParsedPath._(
+      style, root, isRootRelative, List.from(parts), List.from(separators));
 }

--- a/lib/src/path_map.dart
+++ b/lib/src/path_map.dart
@@ -26,7 +26,7 @@ class PathMap<V> extends MapView<String, V> {
   /// Creates a map that uses [context] for equality and hashing.
   static Map<String, V> _create<V>(p.Context context) {
     context ??= p.context;
-    return new LinkedHashMap(
+    return LinkedHashMap(
         equals: (path1, path2) {
           if (path1 == null) return path2 == null;
           if (path2 == null) return false;

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -29,7 +29,7 @@ class PathSet extends IterableBase<String> implements Set<String> {
   /// Creates a set that uses [context] for equality and hashing.
   static Set<String> _create(p.Context context) {
     context ??= p.context;
-    return new LinkedHashSet(
+    return LinkedHashSet(
         equals: (path1, path2) {
           if (path1 == null) return path2 == null;
           if (path2 == null) return false;

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -11,14 +11,14 @@ import 'style/windows.dart';
 abstract class Style {
   /// POSIX-style paths use "/" (forward slash) as separators. Absolute paths
   /// start with "/". Used by UNIX, Linux, Mac OS X, and others.
-  static final Style posix = new PosixStyle();
+  static final Style posix = PosixStyle();
 
   /// Windows paths use `\` (backslash) as separators. Absolute paths start with
   /// a drive letter followed by a colon (example, `C:`) or two backslashes
   /// (`\\`) for UNC paths.
   // TODO(rnystrom): The UNC root prefix should include the drive name too, not
   // just the `\\`.
-  static final Style windows = new WindowsStyle();
+  static final Style windows = WindowsStyle();
 
   /// URLs aren't filesystem paths, but they're supported to make it easier to
   /// manipulate URL paths in the browser.
@@ -26,7 +26,7 @@ abstract class Style {
   /// URLs use "/" (forward slash) as separators. Absolute paths either start
   /// with a protocol and optional hostname (e.g. `http://dartlang.org`,
   /// `file://`) or with "/".
-  static final Style url = new UrlStyle();
+  static final Style url = UrlStyle();
 
   /// The style of the host platform.
   ///
@@ -42,7 +42,7 @@ abstract class Style {
     // style to use.
     if (Uri.base.scheme != 'file') return Style.url;
     if (!Uri.base.path.endsWith('/')) return Style.url;
-    if (new Uri(path: 'a/b').toFilePath() == 'a\\b') return Style.windows;
+    if (Uri(path: 'a/b').toFilePath() == 'a\\b') return Style.windows;
     return Style.posix;
   }
 
@@ -50,7 +50,7 @@ abstract class Style {
   String get name;
 
   /// A [Context] that uses this style.
-  Context get context => new Context(style: this);
+  Context get context => Context(style: this);
 
   @Deprecated("Most Style members will be removed in path 2.0.")
   String get separator;

--- a/lib/src/style/posix.dart
+++ b/lib/src/style/posix.dart
@@ -16,9 +16,9 @@ class PosixStyle extends InternalStyle {
 
   // Deprecated properties.
 
-  final separatorPattern = new RegExp(r'/');
-  final needsSeparatorPattern = new RegExp(r'[^/]$');
-  final rootPattern = new RegExp(r'^/');
+  final separatorPattern = RegExp(r'/');
+  final needsSeparatorPattern = RegExp(r'[^/]$');
+  final rootPattern = RegExp(r'^/');
   final relativeRootPattern = null;
 
   bool containsSeparator(String path) => path.contains('/');
@@ -28,7 +28,7 @@ class PosixStyle extends InternalStyle {
   bool needsSeparator(String path) =>
       path.isNotEmpty && !isSeparator(path.codeUnitAt(path.length - 1));
 
-  int rootLength(String path, {bool withDrive: false}) {
+  int rootLength(String path, {bool withDrive = false}) {
     if (path.isNotEmpty && isSeparator(path.codeUnitAt(0))) return 1;
     return 0;
   }
@@ -41,11 +41,11 @@ class PosixStyle extends InternalStyle {
     if (uri.scheme == '' || uri.scheme == 'file') {
       return Uri.decodeComponent(uri.path);
     }
-    throw new ArgumentError("Uri $uri must have scheme 'file:'.");
+    throw ArgumentError("Uri $uri must have scheme 'file:'.");
   }
 
   Uri absolutePathToUri(String path) {
-    var parsed = new ParsedPath.parse(path, this);
+    var parsed = ParsedPath.parse(path, this);
     if (parsed.parts.isEmpty) {
       // If the path is a bare root (e.g. "/"), [components] will
       // currently be empty. We add two empty components so the URL constructor
@@ -57,6 +57,6 @@ class PosixStyle extends InternalStyle {
       parsed.parts.add("");
     }
 
-    return new Uri(scheme: 'file', pathSegments: parsed.parts);
+    return Uri(scheme: 'file', pathSegments: parsed.parts);
   }
 }

--- a/lib/src/style/url.dart
+++ b/lib/src/style/url.dart
@@ -16,11 +16,10 @@ class UrlStyle extends InternalStyle {
 
   // Deprecated properties.
 
-  final separatorPattern = new RegExp(r'/');
-  final needsSeparatorPattern =
-      new RegExp(r"(^[a-zA-Z][-+.a-zA-Z\d]*://|[^/])$");
-  final rootPattern = new RegExp(r"[a-zA-Z][-+.a-zA-Z\d]*://[^/]*");
-  final relativeRootPattern = new RegExp(r"^/");
+  final separatorPattern = RegExp(r'/');
+  final needsSeparatorPattern = RegExp(r"(^[a-zA-Z][-+.a-zA-Z\d]*://|[^/])$");
+  final rootPattern = RegExp(r"[a-zA-Z][-+.a-zA-Z\d]*://[^/]*");
+  final relativeRootPattern = RegExp(r"^/");
 
   bool containsSeparator(String path) => path.contains('/');
 
@@ -37,7 +36,7 @@ class UrlStyle extends InternalStyle {
     return path.endsWith("://") && rootLength(path) == path.length;
   }
 
-  int rootLength(String path, {bool withDrive: false}) {
+  int rootLength(String path, {bool withDrive = false}) {
     if (path.isEmpty) return 0;
     if (isSeparator(path.codeUnitAt(0))) return 1;
 

--- a/lib/src/style/windows.dart
+++ b/lib/src/style/windows.dart
@@ -21,10 +21,10 @@ class WindowsStyle extends InternalStyle {
 
   // Deprecated properties.
 
-  final separatorPattern = new RegExp(r'[/\\]');
-  final needsSeparatorPattern = new RegExp(r'[^/\\]$');
-  final rootPattern = new RegExp(r'^(\\\\[^\\]+\\[^\\/]+|[a-zA-Z]:[/\\])');
-  final relativeRootPattern = new RegExp(r"^[/\\](?![/\\])");
+  final separatorPattern = RegExp(r'[/\\]');
+  final needsSeparatorPattern = RegExp(r'[^/\\]$');
+  final rootPattern = RegExp(r'^(\\\\[^\\]+\\[^\\/]+|[a-zA-Z]:[/\\])');
+  final relativeRootPattern = RegExp(r"^[/\\](?![/\\])");
 
   bool containsSeparator(String path) => path.contains('/');
 
@@ -36,7 +36,7 @@ class WindowsStyle extends InternalStyle {
     return !isSeparator(path.codeUnitAt(path.length - 1));
   }
 
-  int rootLength(String path, {bool withDrive: false}) {
+  int rootLength(String path, {bool withDrive = false}) {
     if (path.isEmpty) return 0;
     if (path.codeUnitAt(0) == chars.SLASH) return 1;
     if (path.codeUnitAt(0) == chars.BACKSLASH) {
@@ -72,7 +72,7 @@ class WindowsStyle extends InternalStyle {
 
   String pathFromUri(Uri uri) {
     if (uri.scheme != '' && uri.scheme != 'file') {
-      throw new ArgumentError("Uri $uri must have scheme 'file:'.");
+      throw ArgumentError("Uri $uri must have scheme 'file:'.");
     }
 
     var path = uri.path;
@@ -91,7 +91,7 @@ class WindowsStyle extends InternalStyle {
   }
 
   Uri absolutePathToUri(String path) {
-    var parsed = new ParsedPath.parse(path, this);
+    var parsed = ParsedPath.parse(path, this);
     if (parsed.root.startsWith(r'\\')) {
       // Network paths become "file://server/share/path/to/file".
 
@@ -106,7 +106,7 @@ class WindowsStyle extends InternalStyle {
         parsed.parts.add("");
       }
 
-      return new Uri(
+      return Uri(
           scheme: 'file', host: rootParts.first, pathSegments: parsed.parts);
     } else {
       // Drive-letter paths become "file:///C:/path/to/file".
@@ -124,7 +124,7 @@ class WindowsStyle extends InternalStyle {
       parsed.parts
           .insert(0, parsed.root.replaceAll("/", "").replaceAll("\\", ""));
 
-      return new Uri(scheme: 'file', pathSegments: parsed.parts);
+      return Uri(scheme: 'file', pathSegments: parsed.parts);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.6.3-dev
+version: 1.6.3
 
 description: >
   A string-based path manipulation library. All of the path operations you know
@@ -9,7 +9,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: http://github.com/dart-lang/path
 
 environment:
- sdk: '>=2.0.0-dev.62.0 <3.0.0'
+ sdk: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
   test: '>=0.12.42 <2.0.0'

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -12,18 +12,18 @@ import 'package:path/path.dart' as path;
 main() {
   group('new Context()', () {
     test('uses the window location if root and style are omitted', () {
-      var context = new path.Context();
+      var context = path.Context();
       expect(context.current,
           Uri.parse(window.location.href).resolve('.').toString());
     });
 
     test('uses "." if root is omitted', () {
-      var context = new path.Context(style: path.Style.platform);
+      var context = path.Context(style: path.Style.platform);
       expect(context.current, ".");
     });
 
     test('uses the host platform if style is omitted', () {
-      var context = new path.Context();
+      var context = path.Context();
       expect(context.style, path.Style.platform);
     });
   });

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -12,17 +12,17 @@ import 'package:path/path.dart' as path;
 main() {
   group('new Context()', () {
     test('uses the current directory if root and style are omitted', () {
-      var context = new path.Context();
+      var context = path.Context();
       expect(context.current, io.Directory.current.path);
     });
 
     test('uses "." if root is omitted', () {
-      var context = new path.Context(style: path.Style.platform);
+      var context = path.Context(style: path.Style.platform);
       expect(context.current, ".");
     });
 
     test('uses the host platform if style is omitted', () {
-      var context = new path.Context();
+      var context = path.Context();
       expect(context.style, path.Style.platform);
     });
   });

--- a/test/path_map_test.dart
+++ b/test/path_map_test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart';
 void main() {
   group("considers equal", () {
     test("two identical paths", () {
-      var map = new PathMap<int>();
+      var map = PathMap<int>();
       map[join("foo", "bar")] = 1;
       map[join("foo", "bar")] = 2;
       expect(map, hasLength(1));
@@ -17,7 +17,7 @@ void main() {
     });
 
     test("two logically equivalent paths", () {
-      var map = new PathMap<int>();
+      var map = PathMap<int>();
       map["foo"] = 1;
       map[absolute("foo")] = 2;
       expect(map, hasLength(1));
@@ -26,7 +26,7 @@ void main() {
     });
 
     test("two nulls", () {
-      var map = new PathMap<int>();
+      var map = PathMap<int>();
       map[null] = 1;
       map[null] = 2;
       expect(map, hasLength(1));
@@ -36,7 +36,7 @@ void main() {
 
   group("considers unequal", () {
     test("two distinct paths", () {
-      var map = new PathMap<int>();
+      var map = PathMap<int>();
       map["foo"] = 1;
       map["bar"] = 2;
       expect(map, hasLength(2));
@@ -45,7 +45,7 @@ void main() {
     });
 
     test("a path and null", () {
-      var map = new PathMap<int>();
+      var map = PathMap<int>();
       map["foo"] = 1;
       map[null] = 2;
       expect(map, hasLength(2));
@@ -55,7 +55,7 @@ void main() {
   });
 
   test("uses the custom context", () {
-    var map = new PathMap<int>(context: windows);
+    var map = PathMap<int>(context: windows);
     map["FOO"] = 1;
     map["foo"] = 2;
     expect(map, hasLength(1));
@@ -64,14 +64,14 @@ void main() {
 
   group(".of()", () {
     test("copies the existing map's keys", () {
-      var map = new PathMap.of({"foo": 1, "bar": 2});
+      var map = PathMap.of({"foo": 1, "bar": 2});
       expect(map, hasLength(2));
       expect(map, containsPair("foo", 1));
       expect(map, containsPair("bar", 2));
     });
 
     test("uses the second value in the case of duplicates", () {
-      var map = new PathMap.of({"foo": 1, absolute("foo"): 2});
+      var map = PathMap.of({"foo": 1, absolute("foo"): 2});
       expect(map, hasLength(1));
       expect(map, containsPair("foo", 2));
       expect(map, containsPair(absolute("foo"), 2));

--- a/test/path_set_test.dart
+++ b/test/path_set_test.dart
@@ -9,7 +9,7 @@ import 'package:path/path.dart';
 void main() {
   group("considers equal", () {
     test("two identical paths", () {
-      var set = new PathSet();
+      var set = PathSet();
       expect(set.add(join("foo", "bar")), isTrue);
       expect(set.add(join("foo", "bar")), isFalse);
       expect(set, hasLength(1));
@@ -17,7 +17,7 @@ void main() {
     });
 
     test("two logically equivalent paths", () {
-      var set = new PathSet();
+      var set = PathSet();
       expect(set.add("foo"), isTrue);
       expect(set.add(absolute("foo")), isFalse);
       expect(set, hasLength(1));
@@ -26,7 +26,7 @@ void main() {
     });
 
     test("two nulls", () {
-      var set = new PathSet();
+      var set = PathSet();
       expect(set.add(null), isTrue);
       expect(set.add(null), isFalse);
       expect(set, hasLength(1));
@@ -36,7 +36,7 @@ void main() {
 
   group("considers unequal", () {
     test("two distinct paths", () {
-      var set = new PathSet();
+      var set = PathSet();
       expect(set.add("foo"), isTrue);
       expect(set.add("bar"), isTrue);
       expect(set, hasLength(2));
@@ -45,7 +45,7 @@ void main() {
     });
 
     test("a path and null", () {
-      var set = new PathSet();
+      var set = PathSet();
       expect(set.add("foo"), isTrue);
       expect(set.add(null), isTrue);
       expect(set, hasLength(2));
@@ -55,7 +55,7 @@ void main() {
   });
 
   test("uses the custom context", () {
-    var set = new PathSet(context: windows);
+    var set = PathSet(context: windows);
     expect(set.add("FOO"), isTrue);
     expect(set.add("foo"), isFalse);
     expect(set, hasLength(1));
@@ -64,14 +64,14 @@ void main() {
 
   group(".of()", () {
     test("copies the existing set's keys", () {
-      var set = new PathSet.of(["foo", "bar"]);
+      var set = PathSet.of(["foo", "bar"]);
       expect(set, hasLength(2));
       expect(set, contains("foo"));
       expect(set, contains("bar"));
     });
 
     test("uses the first value in the case of duplicates", () {
-      var set = new PathSet.of(["foo", absolute("foo")]);
+      var set = PathSet.of(["foo", absolute("foo")]);
       expect(set, hasLength(1));
       expect(set, contains("foo"));
       expect(set, contains(absolute("foo")));

--- a/test/path_test.dart
+++ b/test/path_test.dart
@@ -27,12 +27,12 @@ main() {
 
   group('new Context()', () {
     test('uses the given current directory', () {
-      var context = new path.Context(current: '/a/b/c');
+      var context = path.Context(current: '/a/b/c');
       expect(context.current, '/a/b/c');
     });
 
     test('uses the given style', () {
-      var context = new path.Context(style: path.Style.windows);
+      var context = path.Context(style: path.Style.windows);
       expect(context.style, path.Style.windows);
     });
   });

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -8,8 +8,7 @@ import 'package:path/path.dart' as path;
 import 'utils.dart';
 
 main() {
-  var context =
-      new path.Context(style: path.Style.posix, current: '/root/path');
+  var context = path.Context(style: path.Style.posix, current: '/root/path');
 
   test('separator', () {
     expect(context.separator, '/');
@@ -367,7 +366,7 @@ main() {
     });
 
     group('from relative root', () {
-      var r = new path.Context(style: path.Style.posix, current: 'foo/bar');
+      var r = path.Context(style: path.Style.posix, current: 'foo/bar');
 
       test('given absolute path', () {
         expect(r.relative('/'), equals('/'));
@@ -388,7 +387,7 @@ main() {
     });
 
     test('from a root with extension', () {
-      var r = new path.Context(style: path.Style.posix, current: '/dir.ext');
+      var r = path.Context(style: path.Style.posix, current: '/dir.ext');
       expect(r.relative('/dir.ext/file'), 'file');
     });
 
@@ -401,8 +400,7 @@ main() {
     });
 
     test('with a root parameter and a relative root', () {
-      var r =
-          new path.Context(style: path.Style.posix, current: 'relative/root');
+      var r = path.Context(style: path.Style.posix, current: 'relative/root');
       expect(r.relative('/foo/bar/baz', from: '/foo/bar'), equals('baz'));
       expect(() => r.relative('..', from: '/foo/bar'), throwsPathException);
       expect(
@@ -411,7 +409,7 @@ main() {
     });
 
     test('from a . root', () {
-      var r = new path.Context(style: path.Style.posix, current: '.');
+      var r = path.Context(style: path.Style.posix, current: '.');
       expect(r.relative('/foo/bar/baz'), equals('/foo/bar/baz'));
       expect(r.relative('foo/bar/baz'), equals('foo/bar/baz'));
     });
@@ -442,7 +440,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.posix, current: 'foo/bar');
+      var r = path.Context(style: path.Style.posix, current: 'foo/bar');
       expect(r.isWithin('.', 'a/b/c'), isTrue);
       expect(r.isWithin('.', '../a/b/c'), isFalse);
       expect(r.isWithin('.', '../../a/foo/b/c'), isFalse);
@@ -479,7 +477,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.posix, current: 'foo/bar');
+      var r = path.Context(style: path.Style.posix, current: 'foo/bar');
       expectEquals(r, 'a/b', 'a/b');
       expectNotEquals(r, '.', 'foo/bar');
       expectNotEquals(r, '.', '../a/b');

--- a/test/relative_test.dart
+++ b/test/relative_test.dart
@@ -11,19 +11,17 @@ import "utils.dart";
 
 void main() {
   test("test relative", () {
-    relativeTest(new path.Context(style: path.Style.posix, current: '.'), '/');
-    relativeTest(new path.Context(style: path.Style.posix, current: '/'), '/');
+    relativeTest(path.Context(style: path.Style.posix, current: '.'), '/');
+    relativeTest(path.Context(style: path.Style.posix, current: '/'), '/');
     relativeTest(
-        new path.Context(style: path.Style.windows, current: r'd:\'), r'c:\');
-    relativeTest(
-        new path.Context(style: path.Style.windows, current: '.'), r'c:\');
-    relativeTest(new path.Context(style: path.Style.url, current: 'file:///'),
-        'http://myserver/');
-    relativeTest(new path.Context(style: path.Style.url, current: '.'),
+        path.Context(style: path.Style.windows, current: r'd:\'), r'c:\');
+    relativeTest(path.Context(style: path.Style.windows, current: '.'), r'c:\');
+    relativeTest(path.Context(style: path.Style.url, current: 'file:///'),
         'http://myserver/');
     relativeTest(
-        new path.Context(style: path.Style.url, current: 'file:///'), '/');
-    relativeTest(new path.Context(style: path.Style.url, current: '.'), '/');
+        path.Context(style: path.Style.url, current: '.'), 'http://myserver/');
+    relativeTest(path.Context(style: path.Style.url, current: 'file:///'), '/');
+    relativeTest(path.Context(style: path.Style.url, current: '.'), '/');
   });
 }
 

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as path;
 import 'utils.dart';
 
 main() {
-  var context = new path.Context(
+  var context = path.Context(
       style: path.Style.url, current: 'http://dartlang.org/root/path');
 
   test('separator', () {
@@ -549,7 +549,7 @@ main() {
     });
 
     group('from relative root', () {
-      var r = new path.Context(style: path.Style.url, current: 'foo/bar');
+      var r = path.Context(style: path.Style.url, current: 'foo/bar');
 
       test('given absolute path', () {
         expect(r.relative('http://google.com/'), equals('http://google.com'));
@@ -574,7 +574,7 @@ main() {
     });
 
     group('from root-relative root', () {
-      var r = new path.Context(style: path.Style.url, current: '/foo/bar');
+      var r = path.Context(style: path.Style.url, current: '/foo/bar');
 
       test('given absolute path', () {
         expect(r.relative('http://google.com/'), equals('http://google.com'));
@@ -599,7 +599,7 @@ main() {
     });
 
     test('from a root with extension', () {
-      var r = new path.Context(style: path.Style.url, current: '/dir.ext');
+      var r = path.Context(style: path.Style.url, current: '/dir.ext');
       expect(r.relative('/dir.ext/file'), 'file');
     });
 
@@ -643,7 +643,7 @@ main() {
     });
 
     test('with a root parameter and a relative root', () {
-      var r = new path.Context(style: path.Style.url, current: 'relative/root');
+      var r = path.Context(style: path.Style.url, current: 'relative/root');
       expect(r.relative('/foo/bar/baz', from: '/foo/bar'), equals('baz'));
       expect(r.relative('/foo/bar/baz', from: 'http://dartlang.org/foo/bar'),
           equals('/foo/bar/baz'));
@@ -669,7 +669,7 @@ main() {
     });
 
     test('from a . root', () {
-      var r = new path.Context(style: path.Style.url, current: '.');
+      var r = path.Context(style: path.Style.url, current: '.');
       expect(r.relative('http://dartlang.org/foo/bar/baz'),
           equals('http://dartlang.org/foo/bar/baz'));
       expect(r.relative('file:///foo/bar/baz'), equals('file:///foo/bar/baz'));
@@ -727,7 +727,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.url, current: 'foo/bar');
+      var r = path.Context(style: path.Style.url, current: 'foo/bar');
       expect(r.isWithin('.', 'a/b/c'), isTrue);
       expect(r.isWithin('.', '../a/b/c'), isFalse);
       expect(r.isWithin('.', '../../a/foo/b/c'), isFalse);
@@ -773,7 +773,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.posix, current: 'foo/bar');
+      var r = path.Context(style: path.Style.posix, current: 'foo/bar');
       expectEquals(r, 'a/b', 'a/b');
       expectNotEquals(r, '.', 'foo/bar');
       expectNotEquals(r, '.', '../a/b');

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -6,7 +6,7 @@ import "package:test/test.dart";
 import "package:path/path.dart" as p;
 
 /// A matcher for a closure that throws a [path.PathException].
-final throwsPathException = throwsA(new TypeMatcher<p.PathException>());
+final throwsPathException = throwsA(TypeMatcher<p.PathException>());
 
 void expectEquals(p.Context context, String path1, String path2) {
   expect(context.equals(path1, path2), isTrue,
@@ -18,7 +18,7 @@ void expectEquals(p.Context context, String path1, String path2) {
 }
 
 void expectNotEquals(p.Context context, String path1, String path2,
-    {bool allowSameHash: false}) {
+    {bool allowSameHash = false}) {
   expect(context.equals(path1, path2), isFalse,
       reason: 'Expected "$path1" not to equal "$path2".');
   expect(context.equals(path2, path1), isFalse,

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 
 main() {
   var context =
-      new path.Context(style: path.Style.windows, current: r'C:\root\path');
+      path.Context(style: path.Style.windows, current: r'C:\root\path');
 
   test('separator', () {
     expect(context.separator, '\\');
@@ -449,7 +449,7 @@ main() {
     });
 
     group('from relative root', () {
-      var r = new path.Context(style: path.Style.windows, current: r'foo\bar');
+      var r = path.Context(style: path.Style.windows, current: r'foo\bar');
 
       test('given absolute path', () {
         expect(r.relative(r'C:\'), equals(r'C:\'));
@@ -472,7 +472,7 @@ main() {
     });
 
     group('from root-relative root', () {
-      var r = new path.Context(style: path.Style.windows, current: r'\foo\bar');
+      var r = path.Context(style: path.Style.windows, current: r'\foo\bar');
 
       test('given absolute path', () {
         expect(r.relative(r'C:\'), equals(r'C:\'));
@@ -497,8 +497,7 @@ main() {
     });
 
     test('from a root with extension', () {
-      var r =
-          new path.Context(style: path.Style.windows, current: r'C:\dir.ext');
+      var r = path.Context(style: path.Style.windows, current: r'C:\dir.ext');
       expect(r.relative(r'C:\dir.ext\file'), 'file');
     });
 
@@ -514,8 +513,8 @@ main() {
     });
 
     test('with a root parameter and a relative root', () {
-      var r = new path.Context(
-          style: path.Style.windows, current: r'relative\root');
+      var r =
+          path.Context(style: path.Style.windows, current: r'relative\root');
       expect(r.relative(r'C:\foo\bar\baz', from: r'C:\foo\bar'), equals('baz'));
       expect(() => r.relative('..', from: r'C:\foo\bar'), throwsPathException);
       expect(r.relative(r'C:\foo\bar\baz', from: r'foo\bar'),
@@ -529,7 +528,7 @@ main() {
     });
 
     test('from a . root', () {
-      var r = new path.Context(style: path.Style.windows, current: '.');
+      var r = path.Context(style: path.Style.windows, current: '.');
       expect(r.relative(r'C:\foo\bar\baz'), equals(r'C:\foo\bar\baz'));
       expect(r.relative(r'foo\bar\baz'), equals(r'foo\bar\baz'));
       expect(r.relative(r'\foo\bar\baz'), equals(r'\foo\bar\baz'));
@@ -576,7 +575,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.windows, current: r'foo\bar');
+      var r = path.Context(style: path.Style.windows, current: r'foo\bar');
       expect(r.isWithin('.', r'a\b\c'), isTrue);
       expect(r.isWithin('.', r'..\a\b\c'), isFalse);
       expect(r.isWithin('.', r'..\..\a\foo\b\c'), isFalse);
@@ -628,7 +627,7 @@ main() {
     });
 
     test('from a relative root', () {
-      var r = new path.Context(style: path.Style.windows, current: r'foo\bar');
+      var r = path.Context(style: path.Style.windows, current: r'foo\bar');
       expectEquals(r, r'a\b', r'a\b');
       expectNotEquals(r, '.', r'foo\bar');
       expectNotEquals(r, '.', r'..\a\b');


### PR DESCRIPTION
This mostly removes optional "new" and "const". Looks like there's a
couple of lingering ":" for named parameters too. There are no
substantive changes, aside from bumping versions in the pubspec to get
ready to publish.