### PR TITLE
Add a UNC examples to rootPrefix and split docs

### DIFF
--- a/lib/path.dart
+++ b/lib/path.dart
@@ -207,7 +207,6 @@ String dirname(String path) => context.dirname(path);
 String extension(String path, [int level = 1]) =>
     context.extension(path, level);
 
-// TODO(nweiz): add a UNC example for Windows once issue 7323 is fixed.
 /// Returns the root of [path], if it's absolute, or the empty string if it's
 /// relative.
 ///
@@ -218,6 +217,7 @@ String extension(String path, [int level = 1]) =>
 ///     // Windows
 ///     p.rootPrefix(r'path\to\foo'); // -> ''
 ///     p.rootPrefix(r'C:\path\to\foo'); // -> r'C:\'
+///     p.rootPrefix(r'\\server\share\a\b'); // -> r'\\server\share'
 ///
 ///     // URL
 ///     p.rootPrefix('path/to/foo'); // -> ''
@@ -295,7 +295,6 @@ String join(String part1,
 /// For a fixed number of parts, [join] is usually terser.
 String joinAll(Iterable<String> parts) => context.joinAll(parts);
 
-// TODO(nweiz): add a UNC example for Windows once issue 7323 is fixed.
 /// Splits [path] into its components using the current platform's [separator].
 ///
 ///     p.split('path/to/foo'); // -> ['path', 'to', 'foo']
@@ -312,6 +311,8 @@ String joinAll(Iterable<String> parts) => context.joinAll(parts);
 ///
 ///     // Windows
 ///     p.split(r'C:\path\to\foo'); // -> [r'C:\', 'path', 'to', 'foo']
+///     p.split(r'\\server\share\path\to\foo');
+///       // -> [r'\\server\share', 'foo', 'bar', 'baz']
 ///
 ///     // Browser
 ///     p.split('http://dartlang.org/path/to/foo');

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -158,7 +158,6 @@ class Context {
   String extension(String path, [int level = 1]) =>
       _parse(path).extension(level);
 
-  // TODO(nweiz): add a UNC example for Windows once issue 7323 is fixed.
   /// Returns the root of [path] if it's absolute, or an empty string if it's
   /// relative.
   ///
@@ -169,6 +168,7 @@ class Context {
   ///     // Windows
   ///     context.rootPrefix(r'path\to\foo'); // -> ''
   ///     context.rootPrefix(r'C:\path\to\foo'); // -> r'C:\'
+  ///     context.rootPrefix(r'\\server\share\a\b'); // -> r'\\server\share'
   ///
   ///     // URL
   ///     context.rootPrefix('path/to/foo'); // -> ''
@@ -296,7 +296,6 @@ class Context {
     return buffer.toString();
   }
 
-  // TODO(nweiz): add a UNC example for Windows once issue 7323 is fixed.
   /// Splits [path] into its components using the current platform's
   /// [separator]. Example:
   ///
@@ -314,6 +313,8 @@ class Context {
   ///
   ///     // Windows
   ///     context.split(r'C:\path\to\foo'); // -> [r'C:\', 'path', 'to', 'foo']
+  ///     context.split(r'\\server\share\path\to\foo');
+  ///       // -> [r'\\server\share', 'foo', 'bar', 'baz']
   List<String> split(String path) {
     final parsed = _parse(path);
     // Filter out empty parts that exist due to multiple separators in a row.

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -16,8 +16,6 @@ abstract class Style {
   /// Windows paths use `\` (backslash) as separators. Absolute paths start with
   /// a drive letter followed by a colon (example, `C:`) or two backslashes
   /// (`\\`) for UNC paths.
-  // TODO(rnystrom): The UNC root prefix should include the drive name too, not
-  // just the `\\`.
   static final Style windows = WindowsStyle();
 
   /// URLs aren't filesystem paths, but they're supported to make it easier to


### PR DESCRIPTION
Resolves some old TODOs. The related issue is closed:
https://github.com/dart-lang/sdk/issues/7323

The change that closed the issues is
https://codereview.chromium.org/59133009

Add examples based on the tests added in that change.

Remove another TODO referencing the issue which I think is resolved.