### PR TITLE
Use dart.dev everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ underlying platform that the program is running on, you can create a
 [Context] and give it an explicit [Style]:
 
 ```dart
-var context = new p.Context(style: Style.windows);
+var context = p.Context(style: Style.windows);
 context.join('directory', 'file.txt');
 ```
 

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -4,23 +4,6 @@
 
 /// A comprehensive, cross-platform path manipulation library.
 ///
-/// ## Installing ##
-///
-/// Use [pub][] to install this package. Add the following to your
-/// `pubspec.yaml` file.
-///
-///     dependencies:
-///       path: any
-///
-/// Then run `pub install`.
-///
-/// For more information, see the [path package on pub.dartlang.org][pkg].
-///
-/// [pub]: http://pub.dartlang.org
-/// [pkg]: http://pub.dartlang.org/packages/path
-///
-/// ## Usage ##
-///
 /// The path library was designed to be imported with a prefix, though you don't
 /// have to if you don't want to:
 ///
@@ -30,7 +13,7 @@
 /// These manipulate path strings based on your current working directory and
 /// the path style (POSIX, Windows, or URLs) of the host platform. For example:
 ///
-///     p.join("directory", "file.txt");
+///     p.join('directory', 'file.txt');
 ///
 /// This calls the top-level [join] function to join "directory" and "file.txt"
 /// using the current platform's directory separator.
@@ -39,8 +22,8 @@
 /// underlying platform that the program is running on, you can create a
 /// [Context] and give it an explicit [Style]:
 ///
-///     var context = new p.Context(style: Style.windows);
-///     context.join("directory", "file.txt");
+///     var context = p.Context(style: Style.windows);
+///     context.join('directory', 'file.txt');
 ///
 /// This will join "directory" and "file.txt" using the Windows path separator,
 /// even when the program is run on a POSIX machine.
@@ -221,8 +204,8 @@ String extension(String path, [int level = 1]) =>
 ///
 ///     // URL
 ///     p.rootPrefix('path/to/foo'); // -> ''
-///     p.rootPrefix('http://dartlang.org/path/to/foo');
-///       // -> 'http://dartlang.org'
+///     p.rootPrefix('https://dart.dev/path/to/foo');
+///       // -> 'https://dart.dev'
 String rootPrefix(String path) => context.rootPrefix(path);
 
 /// Returns `true` if [path] is an absolute path and `false` if it is a
@@ -231,7 +214,7 @@ String rootPrefix(String path) => context.rootPrefix(path);
 /// On POSIX systems, absolute paths start with a `/` (forward slash). On
 /// Windows, an absolute path starts with `\\`, or a drive letter followed by
 /// `:/` or `:\`. For URLs, absolute paths either start with a protocol and
-/// optional hostname (e.g. `http://dartlang.org`, `file://`) or with a `/`.
+/// optional hostname (e.g. `https://dart.dev`, `file://`) or with a `/`.
 ///
 /// URLs that start with `/` are known as "root-relative", since they're
 /// relative to the root of the current URL. Since root-relative paths are still
@@ -315,8 +298,8 @@ String joinAll(Iterable<String> parts) => context.joinAll(parts);
 ///       // -> [r'\\server\share', 'foo', 'bar', 'baz']
 ///
 ///     // Browser
-///     p.split('http://dartlang.org/path/to/foo');
-///       // -> ['http://dartlang.org', 'path', 'to', 'foo']
+///     p.split('https://dart.dev/path/to/foo');
+///       // -> ['https://dart.dev', 'path', 'to', 'foo']
 List<String> split(String path) => context.split(path);
 
 /// Canonicalizes [path].
@@ -367,8 +350,8 @@ String normalize(String path) => context.normalize(path);
 ///     p.relative(r'D:\other', from: r'C:\home'); // -> 'D:\other'
 ///
 ///     // URL
-///     p.relative('http://dartlang.org', from: 'http://pub.dartlang.org');
-///       // -> 'http://dartlang.org'
+///     p.relative('https://dart.dev', from: 'https://pub.dev');
+///       // -> 'https://dart.dev'
 String relative(String path, {String from}) =>
     context.relative(path, from: from);
 
@@ -422,8 +405,8 @@ String setExtension(String path, String extension) =>
 ///     p.fromUri('file:///C:/path/to/foo') // -> r'C:\path\to\foo'
 ///
 ///     // URL
-///     p.fromUri('http://dartlang.org/path/to/foo')
-///       // -> 'http://dartlang.org/path/to/foo'
+///     p.fromUri('https://dart.dev/path/to/foo')
+///       // -> 'https://dart.dev/path/to/foo'
 ///
 /// If [uri] is relative, a relative path will be returned.
 ///
@@ -444,8 +427,8 @@ String fromUri(uri) => context.fromUri(uri);
 ///       // -> Uri.parse('file:///C:/path/to/foo')
 ///
 ///     // URL
-///     p.toUri('http://dartlang.org/path/to/foo')
-///       // -> Uri.parse('http://dartlang.org/path/to/foo')
+///     p.toUri('https://dart.dev/path/to/foo')
+///       // -> Uri.parse('https://dart.dev/path/to/foo')
 ///
 /// If [path] is relative, a relative URI will be returned.
 ///
@@ -463,13 +446,13 @@ Uri toUri(String path) => context.toUri(path);
 ///
 ///     // POSIX at "/root/path"
 ///     p.prettyUri('file:///root/path/a/b.dart'); // -> 'a/b.dart'
-///     p.prettyUri('http://dartlang.org/'); // -> 'http://dartlang.org'
+///     p.prettyUri('https://dart.dev/'); // -> 'https://dart.dev'
 ///
 ///     // Windows at "C:\root\path"
 ///     p.prettyUri('file:///C:/root/path/a/b.dart'); // -> r'a\b.dart'
-///     p.prettyUri('http://dartlang.org/'); // -> 'http://dartlang.org'
+///     p.prettyUri('https://dart.dev/'); // -> 'https://dart.dev'
 ///
-///     // URL at "http://dartlang.org/root/path"
-///     p.prettyUri('http://dartlang.org/root/path/a/b.dart'); // -> r'a/b.dart'
+///     // URL at "https://dart.dev/root/path"
+///     p.prettyUri('https://dart.dev/root/path/a/b.dart'); // -> r'a/b.dart'
 ///     p.prettyUri('file:///root/path'); // -> 'file:///root/path'
 String prettyUri(uri) => context.prettyUri(uri);

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -68,7 +68,7 @@ class Context {
   /// Creates a new path by appending the given path parts to [current].
   /// Equivalent to [join()] with [current] as the first argument. Example:
   ///
-  ///     var context = new Context(current: '/root');
+  ///     var context = Context(current: '/root');
   ///     context.absolute('path', 'to', 'foo'); // -> '/root/path/to/foo'
   ///
   /// If [current] isn't absolute, this won't return an absolute path.
@@ -172,8 +172,8 @@ class Context {
   ///
   ///     // URL
   ///     context.rootPrefix('path/to/foo'); // -> ''
-  ///     context.rootPrefix('http://dartlang.org/path/to/foo');
-  ///       // -> 'http://dartlang.org'
+  ///     context.rootPrefix('https://dart.dev/path/to/foo');
+  ///       // -> 'https://dart.dev'
   String rootPrefix(String path) => path.substring(0, style.rootLength(path));
 
   /// Returns `true` if [path] is an absolute path and `false` if it is a
@@ -182,7 +182,7 @@ class Context {
   /// On POSIX systems, absolute paths start with a `/` (forward slash). On
   /// Windows, an absolute path starts with `\\`, or a drive letter followed by
   /// `:/` or `:\`. For URLs, absolute paths either start with a protocol and
-  /// optional hostname (e.g. `http://dartlang.org`, `file://`) or with a `/`.
+  /// optional hostname (e.g. `https://dart.dev`, `file://`) or with a `/`.
   ///
   /// URLs that start with `/` are known as "root-relative", since they're
   /// relative to the root of the current URL. Since root-relative paths are
@@ -315,6 +315,10 @@ class Context {
   ///     context.split(r'C:\path\to\foo'); // -> [r'C:\', 'path', 'to', 'foo']
   ///     context.split(r'\\server\share\path\to\foo');
   ///       // -> [r'\\server\share', 'foo', 'bar', 'baz']
+  ///
+  ///     // Browser
+  ///     context.split('https://dart.dev/path/to/foo');
+  ///       // -> ['https://dart.dev', 'path', 'to', 'foo']
   List<String> split(String path) {
     final parsed = _parse(path);
     // Filter out empty parts that exist due to multiple separators in a row.
@@ -429,7 +433,7 @@ class Context {
   /// Attempts to convert [path] to an equivalent relative path relative to
   /// [current].
   ///
-  ///     var context = new Context(current: '/root/path');
+  ///     var context = Context(current: '/root/path');
   ///     context.relative('/root/path/a/b.dart'); // -> 'a/b.dart'
   ///     context.relative('/root/other.dart'); // -> '../other.dart'
   ///
@@ -451,7 +455,7 @@ class Context {
   /// This will also return an absolute path if an absolute [path] is passed to
   /// a context with a relative path for [current].
   ///
-  ///     var context = new Context(r'some/relative/path');
+  ///     var context = Context(r'some/relative/path');
   ///     context.relative(r'/absolute/path'); // -> '/absolute/path'
   ///
   /// If [current] is relative, it may be impossible to determine a path from
@@ -986,8 +990,8 @@ class Context {
   ///       // -> r'C:\path\to\foo'
   ///
   ///     // URL
-  ///     context.fromUri('http://dartlang.org/path/to/foo')
-  ///       // -> 'http://dartlang.org/path/to/foo'
+  ///     context.fromUri('https://dart.dev/path/to/foo')
+  ///       // -> 'https://dart.dev/path/to/foo'
   ///
   /// If [uri] is relative, a relative path will be returned.
   ///
@@ -1008,8 +1012,8 @@ class Context {
   ///       // -> Uri.parse('file:///C:/path/to/foo')
   ///
   ///     // URL
-  ///     context.toUri('http://dartlang.org/path/to/foo')
-  ///       // -> Uri.parse('http://dartlang.org/path/to/foo')
+  ///     context.toUri('https://dart.dev/path/to/foo')
+  ///       // -> Uri.parse('https://dart.dev/path/to/foo')
   Uri toUri(String path) {
     if (isRelative(path)) {
       return style.relativePathToUri(path);
@@ -1029,18 +1033,18 @@ class Context {
   /// or path-formatted.
   ///
   ///     // POSIX
-  ///     var context = new Context(current: '/root/path');
+  ///     var context = Context(current: '/root/path');
   ///     context.prettyUri('file:///root/path/a/b.dart'); // -> 'a/b.dart'
-  ///     context.prettyUri('http://dartlang.org/'); // -> 'http://dartlang.org'
+  ///     context.prettyUri('https://dart.dev/'); // -> 'https://dart.dev'
   ///
   ///     // Windows
-  ///     var context = new Context(current: r'C:\root\path');
+  ///     var context = Context(current: r'C:\root\path');
   ///     context.prettyUri('file:///C:/root/path/a/b.dart'); // -> r'a\b.dart'
-  ///     context.prettyUri('http://dartlang.org/'); // -> 'http://dartlang.org'
+  ///     context.prettyUri('https://dart.dev/'); // -> 'https://dart.dev'
   ///
   ///     // URL
-  ///     var context = new Context(current: 'http://dartlang.org/root/path');
-  ///     context.prettyUri('http://dartlang.org/root/path/a/b.dart');
+  ///     var context = Context(current: 'https://dart.dev/root/path');
+  ///     context.prettyUri('https://dart.dev/root/path/a/b.dart');
   ///         // -> r'a/b.dart'
   ///     context.prettyUri('file:///root/path'); // -> 'file:///root/path'
   String prettyUri(uri) {

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -22,7 +22,7 @@ abstract class Style {
   /// manipulate URL paths in the browser.
   ///
   /// URLs use "/" (forward slash) as separators. Absolute paths either start
-  /// with a protocol and optional hostname (e.g. `http://dartlang.org`,
+  /// with a protocol and optional hostname (e.g. `https://dart.dev`,
   /// `file://`) or with "/".
   static final Style url = UrlStyle();
 

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -297,8 +297,8 @@ void main() {
     test('does not walk before root on absolute paths', () {
       expect(context.normalize('..'), '..');
       expect(context.normalize('../'), '..');
-      expect(context.normalize('http://dartlang.org/..'), 'http:');
-      expect(context.normalize('http://dartlang.org/../../a'), 'a');
+      expect(context.normalize('https://dart.dev/..'), 'https:');
+      expect(context.normalize('https://dart.dev/../../a'), 'a');
       expect(context.normalize('file:///..'), '.');
       expect(context.normalize('file:///../../a'), '../a');
       expect(context.normalize('/..'), '/');
@@ -572,7 +572,7 @@ void main() {
           '/path/to/foo#bar');
       expect(context.fromUri(Uri.parse('_%7B_%7D_%60_%5E_%20_%22_%25_')),
           r'_{_}_`_^_ _"_%_');
-      expect(() => context.fromUri(Uri.parse('http://dartlang.org')),
+      expect(() => context.fromUri(Uri.parse('https://dart.dev')),
           throwsArgumentError);
     });
 
@@ -604,8 +604,7 @@ void main() {
     });
 
     test('with an http: URI', () {
-      expect(context.prettyUri('http://dartlang.org/a/b'),
-          'http://dartlang.org/a/b');
+      expect(context.prettyUri('https://dart.dev/a/b'), 'https://dart.dev/a/b');
     });
 
     test('with a relative URI', () {

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -9,7 +9,7 @@ import 'utils.dart';
 
 void main() {
   final context = path.Context(
-      style: path.Style.url, current: 'http://dartlang.org/root/path');
+      style: path.Style.url, current: 'https://dart.dev/root/path');
 
   test('separator', () {
     expect(context.separator, '/');
@@ -30,13 +30,12 @@ void main() {
     expect(context.rootPrefix(''), '');
     expect(context.rootPrefix('a'), '');
     expect(context.rootPrefix('a/b'), '');
-    expect(
-        context.rootPrefix('http://dartlang.org/a/c'), 'http://dartlang.org');
+    expect(context.rootPrefix('https://dart.dev/a/c'), 'https://dart.dev');
     expect(context.rootPrefix('file:///a/c'), 'file://');
     expect(context.rootPrefix('/a/c'), '/');
-    expect(context.rootPrefix('http://dartlang.org/'), 'http://dartlang.org');
+    expect(context.rootPrefix('https://dart.dev/'), 'https://dart.dev');
     expect(context.rootPrefix('file:///'), 'file://');
-    expect(context.rootPrefix('http://dartlang.org'), 'http://dartlang.org');
+    expect(context.rootPrefix('https://dart.dev'), 'https://dart.dev');
     expect(context.rootPrefix('file://'), 'file://');
     expect(context.rootPrefix('/'), '/');
     expect(context.rootPrefix('foo/bar://'), '');
@@ -53,18 +52,18 @@ void main() {
     expect(context.dirname('a/'), '.');
     expect(context.dirname('a/.'), 'a');
     expect(context.dirname(r'a\b/c'), r'a\b');
-    expect(context.dirname('http://dartlang.org/a'), 'http://dartlang.org');
+    expect(context.dirname('https://dart.dev/a'), 'https://dart.dev');
     expect(context.dirname('file:///a'), 'file://');
     expect(context.dirname('/a'), '/');
-    expect(context.dirname('http://dartlang.org///a'), 'http://dartlang.org');
+    expect(context.dirname('https://dart.dev///a'), 'https://dart.dev');
     expect(context.dirname('file://///a'), 'file://');
     expect(context.dirname('///a'), '/');
-    expect(context.dirname('http://dartlang.org/'), 'http://dartlang.org');
-    expect(context.dirname('http://dartlang.org'), 'http://dartlang.org');
+    expect(context.dirname('https://dart.dev/'), 'https://dart.dev');
+    expect(context.dirname('https://dart.dev'), 'https://dart.dev');
     expect(context.dirname('file:///'), 'file://');
     expect(context.dirname('file://'), 'file://');
     expect(context.dirname('/'), '/');
-    expect(context.dirname('http://dartlang.org///'), 'http://dartlang.org');
+    expect(context.dirname('https://dart.dev///'), 'https://dart.dev');
     expect(context.dirname('file://///'), 'file://');
     expect(context.dirname('///'), '/');
     expect(context.dirname('a/b/'), 'a');
@@ -83,11 +82,11 @@ void main() {
     expect(context.basename('a/'), 'a');
     expect(context.basename('a/.'), '.');
     expect(context.basename(r'a\b/c'), 'c');
-    expect(context.basename('http://dartlang.org/a'), 'a');
+    expect(context.basename('https://dart.dev/a'), 'a');
     expect(context.basename('file:///a'), 'a');
     expect(context.basename('/a'), 'a');
-    expect(context.basename('http://dartlang.org/'), 'http://dartlang.org');
-    expect(context.basename('http://dartlang.org'), 'http://dartlang.org');
+    expect(context.basename('https://dart.dev/'), 'https://dart.dev');
+    expect(context.basename('https://dart.dev'), 'https://dart.dev');
     expect(context.basename('file:///'), 'file://');
     expect(context.basename('file://'), 'file://');
     expect(context.basename('/'), '/');
@@ -124,15 +123,15 @@ void main() {
     expect(context.isAbsolute(''), false);
     expect(context.isAbsolute('a'), false);
     expect(context.isAbsolute('a/b'), false);
-    expect(context.isAbsolute('http://dartlang.org/a'), true);
+    expect(context.isAbsolute('https://dart.dev/a'), true);
     expect(context.isAbsolute('file:///a'), true);
     expect(context.isAbsolute('/a'), true);
-    expect(context.isAbsolute('http://dartlang.org/a/b'), true);
+    expect(context.isAbsolute('https://dart.dev/a/b'), true);
     expect(context.isAbsolute('file:///a/b'), true);
     expect(context.isAbsolute('/a/b'), true);
-    expect(context.isAbsolute('http://dartlang.org/'), true);
+    expect(context.isAbsolute('https://dart.dev/'), true);
     expect(context.isAbsolute('file:///'), true);
-    expect(context.isAbsolute('http://dartlang.org'), true);
+    expect(context.isAbsolute('https://dart.dev'), true);
     expect(context.isAbsolute('file://'), true);
     expect(context.isAbsolute('/'), true);
     expect(context.isAbsolute('~'), false);
@@ -149,15 +148,15 @@ void main() {
     expect(context.isRelative(''), true);
     expect(context.isRelative('a'), true);
     expect(context.isRelative('a/b'), true);
-    expect(context.isRelative('http://dartlang.org/a'), false);
+    expect(context.isRelative('https://dart.dev/a'), false);
     expect(context.isRelative('file:///a'), false);
     expect(context.isRelative('/a'), false);
-    expect(context.isRelative('http://dartlang.org/a/b'), false);
+    expect(context.isRelative('https://dart.dev/a/b'), false);
     expect(context.isRelative('file:///a/b'), false);
     expect(context.isRelative('/a/b'), false);
-    expect(context.isRelative('http://dartlang.org/'), false);
+    expect(context.isRelative('https://dart.dev/'), false);
     expect(context.isRelative('file:///'), false);
-    expect(context.isRelative('http://dartlang.org'), false);
+    expect(context.isRelative('https://dart.dev'), false);
     expect(context.isRelative('file://'), false);
     expect(context.isRelative('/'), false);
     expect(context.isRelative('~'), true);
@@ -174,15 +173,15 @@ void main() {
     expect(context.isRootRelative(''), false);
     expect(context.isRootRelative('a'), false);
     expect(context.isRootRelative('a/b'), false);
-    expect(context.isRootRelative('http://dartlang.org/a'), false);
+    expect(context.isRootRelative('https://dart.dev/a'), false);
     expect(context.isRootRelative('file:///a'), false);
     expect(context.isRootRelative('/a'), true);
-    expect(context.isRootRelative('http://dartlang.org/a/b'), false);
+    expect(context.isRootRelative('https://dart.dev/a/b'), false);
     expect(context.isRootRelative('file:///a/b'), false);
     expect(context.isRootRelative('/a/b'), true);
-    expect(context.isRootRelative('http://dartlang.org/'), false);
+    expect(context.isRootRelative('https://dart.dev/'), false);
     expect(context.isRootRelative('file:///'), false);
-    expect(context.isRootRelative('http://dartlang.org'), false);
+    expect(context.isRootRelative('https://dart.dev'), false);
     expect(context.isRootRelative('file://'), false);
     expect(context.isRootRelative('/'), true);
     expect(context.isRootRelative('~'), false);
@@ -214,16 +213,15 @@ void main() {
     });
 
     test('ignores parts before an absolute path', () {
-      expect(context.join('a', 'http://dartlang.org', 'b', 'c'),
-          'http://dartlang.org/b/c');
+      expect(context.join('a', 'https://dart.dev', 'b', 'c'),
+          'https://dart.dev/b/c');
       expect(context.join('a', 'file://', 'b', 'c'), 'file:///b/c');
       expect(context.join('a', '/', 'b', 'c'), '/b/c');
-      expect(context.join('a', '/b', 'http://dartlang.org/c', 'd'),
-          'http://dartlang.org/c/d');
+      expect(context.join('a', '/b', 'https://dart.dev/c', 'd'),
+          'https://dart.dev/c/d');
       expect(
-          context.join(
-              'a', 'http://google.com/b', 'http://dartlang.org/c', 'd'),
-          'http://dartlang.org/c/d');
+          context.join('a', 'http://google.com/b', 'https://dart.dev/c', 'd'),
+          'https://dart.dev/c/d');
       expect(context.join('a', '/b', '/c', 'd'), '/c/d');
       expect(context.join('a', r'c:\b', 'c', 'd'), r'c:\b/c/d');
       expect(context.join('a', 'package:foo/bar', 'c', 'd'),
@@ -232,8 +230,8 @@ void main() {
     });
 
     test('preserves roots before a root-relative path', () {
-      expect(context.join('http://dartlang.org', 'a', '/b', 'c'),
-          'http://dartlang.org/b/c');
+      expect(context.join('https://dart.dev', 'a', '/b', 'c'),
+          'https://dart.dev/b/c');
       expect(context.join('file://', 'a', '/b', 'c'), 'file:///b/c');
       expect(context.join('file://', 'a', '/b', 'c', '/d'), 'file:///d');
       expect(context.join('package:foo/bar.dart', '/baz.dart'),
@@ -294,16 +292,16 @@ void main() {
     });
 
     test('ignores parts before an absolute path', () {
-      expect(context.joinAll(['a', 'http://dartlang.org', 'b', 'c']),
-          'http://dartlang.org/b/c');
+      expect(context.joinAll(['a', 'https://dart.dev', 'b', 'c']),
+          'https://dart.dev/b/c');
       expect(context.joinAll(['a', 'file://', 'b', 'c']), 'file:///b/c');
       expect(context.joinAll(['a', '/', 'b', 'c']), '/b/c');
-      expect(context.joinAll(['a', '/b', 'http://dartlang.org/c', 'd']),
-          'http://dartlang.org/c/d');
+      expect(context.joinAll(['a', '/b', 'https://dart.dev/c', 'd']),
+          'https://dart.dev/c/d');
       expect(
-          context.joinAll(
-              ['a', 'http://google.com/b', 'http://dartlang.org/c', 'd']),
-          'http://dartlang.org/c/d');
+          context
+              .joinAll(['a', 'http://google.com/b', 'https://dart.dev/c', 'd']),
+          'https://dart.dev/c/d');
       expect(context.joinAll(['a', '/b', '/c', 'd']), '/c/d');
       expect(context.joinAll(['a', r'c:\b', 'c', 'd']), r'c:\b/c/d');
       expect(context.joinAll(['a', 'package:foo/bar', 'c', 'd']),
@@ -312,8 +310,8 @@ void main() {
     });
 
     test('preserves roots before a root-relative path', () {
-      expect(context.joinAll(['http://dartlang.org', 'a', '/b', 'c']),
-          'http://dartlang.org/b/c');
+      expect(context.joinAll(['https://dart.dev', 'a', '/b', 'c']),
+          'https://dart.dev/b/c');
       expect(context.joinAll(['file://', 'a', '/b', 'c']), 'file:///b/c');
       expect(context.joinAll(['file://', 'a', '/b', 'c', '/d']), 'file:///d');
     });
@@ -334,22 +332,19 @@ void main() {
       expect(context.split('.'), equals(['.']));
       expect(context.split(''), equals([]));
       expect(context.split('foo/'), equals(['foo']));
-      expect(context.split('http://dartlang.org//'),
-          equals(['http://dartlang.org']));
+      expect(context.split('https://dart.dev//'), equals(['https://dart.dev']));
       expect(context.split('file:////'), equals(['file://']));
       expect(context.split('//'), equals(['/']));
     });
 
     test('includes the root for absolute paths', () {
-      expect(context.split('http://dartlang.org/foo/bar/baz'),
-          equals(['http://dartlang.org', 'foo', 'bar', 'baz']));
+      expect(context.split('https://dart.dev/foo/bar/baz'),
+          equals(['https://dart.dev', 'foo', 'bar', 'baz']));
       expect(context.split('file:///foo/bar/baz'),
           equals(['file://', 'foo', 'bar', 'baz']));
       expect(context.split('/foo/bar/baz'), equals(['/', 'foo', 'bar', 'baz']));
-      expect(context.split('http://dartlang.org/'),
-          equals(['http://dartlang.org']));
-      expect(context.split('http://dartlang.org'),
-          equals(['http://dartlang.org']));
+      expect(context.split('https://dart.dev/'), equals(['https://dart.dev']));
+      expect(context.split('https://dart.dev'), equals(['https://dart.dev']));
       expect(context.split('file:///'), equals(['file://']));
       expect(context.split('file://'), equals(['file://']));
       expect(context.split('/'), equals(['/']));
@@ -362,8 +357,8 @@ void main() {
       expect(context.normalize('.'), '.');
       expect(context.normalize('..'), '..');
       expect(context.normalize('a'), 'a');
-      expect(context.normalize('http://dartlang.org/'), 'http://dartlang.org');
-      expect(context.normalize('http://dartlang.org'), 'http://dartlang.org');
+      expect(context.normalize('https://dart.dev/'), 'https://dart.dev');
+      expect(context.normalize('https://dart.dev'), 'https://dart.dev');
       expect(context.normalize('file://'), 'file://');
       expect(context.normalize('file:///'), 'file://');
       expect(context.normalize('/'), '/');
@@ -386,11 +381,10 @@ void main() {
 
     test('eliminates "." parts', () {
       expect(context.normalize('./'), '.');
-      expect(context.normalize('http://dartlang.org/.'), 'http://dartlang.org');
+      expect(context.normalize('https://dart.dev/.'), 'https://dart.dev');
       expect(context.normalize('file:///.'), 'file://');
       expect(context.normalize('/.'), '/');
-      expect(
-          context.normalize('http://dartlang.org/./'), 'http://dartlang.org');
+      expect(context.normalize('https://dart.dev/./'), 'https://dart.dev');
       expect(context.normalize('file:///./'), 'file://');
       expect(context.normalize('/./'), '/');
       expect(context.normalize('./.'), '.');
@@ -406,16 +400,15 @@ void main() {
       expect(context.normalize('../'), '..');
       expect(context.normalize('../../..'), '../../..');
       expect(context.normalize('../../../'), '../../..');
-      expect(
-          context.normalize('http://dartlang.org/..'), 'http://dartlang.org');
+      expect(context.normalize('https://dart.dev/..'), 'https://dart.dev');
       expect(context.normalize('file:///..'), 'file://');
       expect(context.normalize('/..'), '/');
-      expect(context.normalize('http://dartlang.org/../../..'),
-          'http://dartlang.org');
+      expect(
+          context.normalize('https://dart.dev/../../..'), 'https://dart.dev');
       expect(context.normalize('file:///../../..'), 'file://');
       expect(context.normalize('/../../..'), '/');
-      expect(context.normalize('http://dartlang.org/../../../a'),
-          'http://dartlang.org/a');
+      expect(context.normalize('https://dart.dev/../../../a'),
+          'https://dart.dev/a');
       expect(context.normalize('file:///../../../a'), 'file:///a');
       expect(context.normalize('/../../../a'), '/a');
       expect(context.normalize('c:/..'), 'c:');
@@ -434,10 +427,8 @@ void main() {
     test('does not walk before root on absolute paths', () {
       expect(context.normalize('..'), '..');
       expect(context.normalize('../'), '..');
-      expect(
-          context.normalize('http://dartlang.org/..'), 'http://dartlang.org');
-      expect(context.normalize('http://dartlang.org/../a'),
-          'http://dartlang.org/a');
+      expect(context.normalize('https://dart.dev/..'), 'https://dart.dev');
+      expect(context.normalize('https://dart.dev/../a'), 'https://dart.dev/a');
       expect(context.normalize('file:///..'), 'file://');
       expect(context.normalize('file:///../a'), 'file:///a');
       expect(context.normalize('/..'), '/');
@@ -466,11 +457,11 @@ void main() {
     });
 
     test('when canonicalizing', () {
-      expect(context.canonicalize('.'), 'http://dartlang.org/root/path');
+      expect(context.canonicalize('.'), 'https://dart.dev/root/path');
       expect(context.canonicalize('foo/bar'),
-          'http://dartlang.org/root/path/foo/bar');
-      expect(context.canonicalize('FoO'), 'http://dartlang.org/root/path/FoO');
-      expect(context.canonicalize('/foo'), 'http://dartlang.org/foo');
+          'https://dart.dev/root/path/foo/bar');
+      expect(context.canonicalize('FoO'), 'https://dart.dev/root/path/FoO');
+      expect(context.canonicalize('/foo'), 'https://dart.dev/foo');
       expect(context.canonicalize('http://google.com/foo'),
           'http://google.com/foo');
     });
@@ -479,34 +470,32 @@ void main() {
   group('relative', () {
     group('from absolute root', () {
       test('given absolute path in root', () {
-        expect(context.relative('http://dartlang.org'), '../..');
-        expect(context.relative('http://dartlang.org/'), '../..');
+        expect(context.relative('https://dart.dev'), '../..');
+        expect(context.relative('https://dart.dev/'), '../..');
         expect(context.relative('/'), '../..');
-        expect(context.relative('http://dartlang.org/root'), '..');
+        expect(context.relative('https://dart.dev/root'), '..');
         expect(context.relative('/root'), '..');
-        expect(context.relative('http://dartlang.org/root/path'), '.');
+        expect(context.relative('https://dart.dev/root/path'), '.');
         expect(context.relative('/root/path'), '.');
-        expect(context.relative('http://dartlang.org/root/path/a'), 'a');
+        expect(context.relative('https://dart.dev/root/path/a'), 'a');
         expect(context.relative('/root/path/a'), 'a');
-        expect(context.relative('http://dartlang.org/root/path/a/b.txt'),
-            'a/b.txt');
-        expect(context.relative('/root/path/a/b.txt'), 'a/b.txt');
         expect(
-            context.relative('http://dartlang.org/root/a/b.txt'), '../a/b.txt');
+            context.relative('https://dart.dev/root/path/a/b.txt'), 'a/b.txt');
+        expect(context.relative('/root/path/a/b.txt'), 'a/b.txt');
+        expect(context.relative('https://dart.dev/root/a/b.txt'), '../a/b.txt');
         expect(context.relative('/root/a/b.txt'), '../a/b.txt');
       });
 
       test('given absolute path outside of root', () {
-        expect(context.relative('http://dartlang.org/a/b'), '../../a/b');
+        expect(context.relative('https://dart.dev/a/b'), '../../a/b');
         expect(context.relative('/a/b'), '../../a/b');
-        expect(context.relative('http://dartlang.org/root/path/a'), 'a');
+        expect(context.relative('https://dart.dev/root/path/a'), 'a');
         expect(context.relative('/root/path/a'), 'a');
-        expect(context.relative('http://dartlang.org/root/path/a/b.txt'),
-            'a/b.txt');
-        expect(context.relative('http://dartlang.org/root/path/a/b.txt'),
-            'a/b.txt');
         expect(
-            context.relative('http://dartlang.org/root/a/b.txt'), '../a/b.txt');
+            context.relative('https://dart.dev/root/path/a/b.txt'), 'a/b.txt');
+        expect(
+            context.relative('https://dart.dev/root/path/a/b.txt'), 'a/b.txt');
+        expect(context.relative('https://dart.dev/root/a/b.txt'), '../a/b.txt');
       });
 
       test('given absolute path with different hostname/protocol', () {
@@ -527,23 +516,21 @@ void main() {
       });
 
       test('is case-sensitive', () {
-        expect(context.relative('HtTp://dartlang.org/root'),
-            'HtTp://dartlang.org/root');
-        expect(context.relative('http://DaRtLaNg.OrG/root'),
-            'http://DaRtLaNg.OrG/root');
+        expect(
+            context.relative('HtTps://dart.dev/root'), 'HtTps://dart.dev/root');
+        expect(
+            context.relative('https://DaRt.DeV/root'), 'https://DaRt.DeV/root');
         expect(context.relative('/RoOt'), '../../RoOt');
         expect(context.relative('/rOoT/pAtH/a'), '../../rOoT/pAtH/a');
       });
 
       // Regression
       test('from root-only path', () {
-        expect(
-            context.relative('http://dartlang.org',
-                from: 'http://dartlang.org'),
+        expect(context.relative('https://dart.dev', from: 'https://dart.dev'),
             '.');
         expect(
-            context.relative('http://dartlang.org/root/path',
-                from: 'http://dartlang.org'),
+            context.relative('https://dart.dev/root/path',
+                from: 'https://dart.dev'),
             'root/path');
       });
     });
@@ -605,34 +592,31 @@ void main() {
 
     test('with a root parameter', () {
       expect(context.relative('/foo/bar/baz', from: '/foo/bar'), equals('baz'));
-      expect(
-          context.relative('/foo/bar/baz', from: 'http://dartlang.org/foo/bar'),
+      expect(context.relative('/foo/bar/baz', from: 'https://dart.dev/foo/bar'),
+          equals('baz'));
+      expect(context.relative('https://dart.dev/foo/bar/baz', from: '/foo/bar'),
           equals('baz'));
       expect(
-          context.relative('http://dartlang.org/foo/bar/baz', from: '/foo/bar'),
-          equals('baz'));
-      expect(
-          context.relative('http://dartlang.org/foo/bar/baz',
+          context.relative('https://dart.dev/foo/bar/baz',
               from: 'file:///foo/bar'),
-          equals('http://dartlang.org/foo/bar/baz'));
+          equals('https://dart.dev/foo/bar/baz'));
       expect(
-          context.relative('http://dartlang.org/foo/bar/baz',
-              from: 'http://dartlang.org/foo/bar'),
+          context.relative('https://dart.dev/foo/bar/baz',
+              from: 'https://dart.dev/foo/bar'),
           equals('baz'));
       expect(context.relative('/foo/bar/baz', from: 'file:///foo/bar'),
-          equals('http://dartlang.org/foo/bar/baz'));
+          equals('https://dart.dev/foo/bar/baz'));
       expect(context.relative('file:///foo/bar/baz', from: '/foo/bar'),
           equals('file:///foo/bar/baz'));
 
       expect(context.relative('..', from: '/foo/bar'), equals('../../root'));
-      expect(context.relative('..', from: 'http://dartlang.org/foo/bar'),
+      expect(context.relative('..', from: 'https://dart.dev/foo/bar'),
           equals('../../root'));
       expect(context.relative('..', from: 'file:///foo/bar'),
-          equals('http://dartlang.org/root'));
+          equals('https://dart.dev/root'));
       expect(context.relative('..', from: '/foo/bar'), equals('../../root'));
 
-      expect(
-          context.relative('http://dartlang.org/foo/bar/baz', from: 'foo/bar'),
+      expect(context.relative('https://dart.dev/foo/bar/baz', from: 'foo/bar'),
           equals('../../../../foo/bar/baz'));
       expect(context.relative('file:///foo/bar/baz', from: 'foo/bar'),
           equals('file:///foo/bar/baz'));
@@ -645,21 +629,20 @@ void main() {
     test('with a root parameter and a relative root', () {
       final r = path.Context(style: path.Style.url, current: 'relative/root');
       expect(r.relative('/foo/bar/baz', from: '/foo/bar'), equals('baz'));
-      expect(r.relative('/foo/bar/baz', from: 'http://dartlang.org/foo/bar'),
+      expect(r.relative('/foo/bar/baz', from: 'https://dart.dev/foo/bar'),
           equals('/foo/bar/baz'));
-      expect(r.relative('http://dartlang.org/foo/bar/baz', from: '/foo/bar'),
-          equals('http://dartlang.org/foo/bar/baz'));
+      expect(r.relative('https://dart.dev/foo/bar/baz', from: '/foo/bar'),
+          equals('https://dart.dev/foo/bar/baz'));
       expect(
-          r.relative('http://dartlang.org/foo/bar/baz',
-              from: 'file:///foo/bar'),
-          equals('http://dartlang.org/foo/bar/baz'));
+          r.relative('https://dart.dev/foo/bar/baz', from: 'file:///foo/bar'),
+          equals('https://dart.dev/foo/bar/baz'));
       expect(
-          r.relative('http://dartlang.org/foo/bar/baz',
-              from: 'http://dartlang.org/foo/bar'),
+          r.relative('https://dart.dev/foo/bar/baz',
+              from: 'https://dart.dev/foo/bar'),
           equals('baz'));
 
-      expect(r.relative('http://dartlang.org/foo/bar/baz', from: 'foo/bar'),
-          equals('http://dartlang.org/foo/bar/baz'));
+      expect(r.relative('https://dart.dev/foo/bar/baz', from: 'foo/bar'),
+          equals('https://dart.dev/foo/bar/baz'));
       expect(r.relative('file:///foo/bar/baz', from: 'foo/bar'),
           equals('file:///foo/bar/baz'));
       expect(
@@ -670,8 +653,8 @@ void main() {
 
     test('from a . root', () {
       final r = path.Context(style: path.Style.url, current: '.');
-      expect(r.relative('http://dartlang.org/foo/bar/baz'),
-          equals('http://dartlang.org/foo/bar/baz'));
+      expect(r.relative('https://dart.dev/foo/bar/baz'),
+          equals('https://dart.dev/foo/bar/baz'));
       expect(r.relative('file:///foo/bar/baz'), equals('file:///foo/bar/baz'));
       expect(r.relative('/foo/bar/baz'), equals('/foo/bar/baz'));
       expect(r.relative('foo/bar/baz'), equals('foo/bar/baz'));
@@ -684,20 +667,17 @@ void main() {
       expect(context.isWithin('foo/bar', 'foo/bar/baz'), isTrue);
       expect(context.isWithin('foo/bar', 'foo/baz'), isFalse);
       expect(context.isWithin('foo/bar', '../path/foo/bar/baz'), isTrue);
-      expect(
-          context.isWithin(
-              'http://dartlang.org', 'http://dartlang.org/foo/bar'),
+      expect(context.isWithin('https://dart.dev', 'https://dart.dev/foo/bar'),
           isTrue);
       expect(
-          context.isWithin(
-              'http://dartlang.org', 'http://pub.dartlang.org/foo/bar'),
+          context.isWithin('https://dart.dev', 'http://psub.dart.dev/foo/bar'),
           isFalse);
-      expect(context.isWithin('http://dartlang.org', '/foo/bar'), isTrue);
-      expect(context.isWithin('http://dartlang.org/foo', '/foo/bar'), isTrue);
-      expect(context.isWithin('http://dartlang.org/foo', '/bar/baz'), isFalse);
-      expect(context.isWithin('baz', 'http://dartlang.org/root/path/baz/bang'),
+      expect(context.isWithin('https://dart.dev', '/foo/bar'), isTrue);
+      expect(context.isWithin('https://dart.dev/foo', '/foo/bar'), isTrue);
+      expect(context.isWithin('https://dart.dev/foo', '/bar/baz'), isFalse);
+      expect(context.isWithin('baz', 'https://dart.dev/root/path/baz/bang'),
           isTrue);
-      expect(context.isWithin('baz', 'http://dartlang.org/root/path/bang/baz'),
+      expect(context.isWithin('baz', 'https://dart.dev/root/path/bang/baz'),
           isFalse);
     });
 
@@ -714,13 +694,13 @@ void main() {
       expect(context.isWithin('foo/bar', 'foo/bar/baz/../qux'), isTrue);
       expect(context.isWithin('http://example.org/', 'http://example.com/foo'),
           isFalse);
-      expect(context.isWithin('http://example.org/', 'http://dartlang.org/foo'),
+      expect(context.isWithin('http://example.org/', 'https://dart.dev/foo'),
           isFalse);
     });
 
     test('with root-relative paths', () {
-      expect(context.isWithin('/foo', 'http://dartlang.org/foo/bar'), isTrue);
-      expect(context.isWithin('http://dartlang.org/foo', '/foo/bar'), isTrue);
+      expect(context.isWithin('/foo', 'https://dart.dev/foo/bar'), isTrue);
+      expect(context.isWithin('https://dart.dev/foo', '/foo/bar'), isTrue);
       expect(context.isWithin('/root', 'foo/bar'), isTrue);
       expect(context.isWithin('foo', '/root/path/foo/bar'), isTrue);
       expect(context.isWithin('/foo', '/foo/bar'), isTrue);
@@ -731,9 +711,9 @@ void main() {
       expect(r.isWithin('.', 'a/b/c'), isTrue);
       expect(r.isWithin('.', '../a/b/c'), isFalse);
       expect(r.isWithin('.', '../../a/foo/b/c'), isFalse);
-      expect(r.isWithin('http://dartlang.org/', 'http://dartlang.org/baz/bang'),
-          isTrue);
-      expect(r.isWithin('.', 'http://dartlang.org/baz/bang'), isFalse);
+      expect(
+          r.isWithin('https://dart.dev/', 'https://dart.dev/baz/bang'), isTrue);
+      expect(r.isWithin('.', 'https://dart.dev/baz/bang'), isFalse);
     });
   });
 
@@ -745,7 +725,7 @@ void main() {
       expectNotEquals(context, 'foo/bar', 'foo/baz');
       expectEquals(context, 'foo/bar', '../path/foo/bar');
       expectEquals(context, 'http://google.com', 'http://google.com');
-      expectEquals(context, 'http://dartlang.org', '../..');
+      expectEquals(context, 'https://dart.dev', '../..');
       expectEquals(context, 'baz', '/root/path/baz');
     });
 
@@ -763,11 +743,11 @@ void main() {
       expectEquals(context, 'foo/bar', 'foo/bar/baz/..');
       expectNotEquals(context, 'FoO/bAr', 'foo/bar');
       expectEquals(context, 'http://google.com', 'http://google.com/');
-      expectEquals(context, 'http://dartlang.org/root', '..');
+      expectEquals(context, 'https://dart.dev/root', '..');
     });
 
     test('with root-relative paths', () {
-      expectEquals(context, '/foo', 'http://dartlang.org/foo');
+      expectEquals(context, '/foo', 'https://dart.dev/foo');
       expectNotEquals(context, '/foo', 'http://google.com/foo');
       expectEquals(context, '/root/path/foo/bar', 'foo/bar');
     });
@@ -785,33 +765,32 @@ void main() {
 
   group('absolute', () {
     test('allows up to seven parts', () {
-      expect(context.absolute('a'), 'http://dartlang.org/root/path/a');
-      expect(context.absolute('a', 'b'), 'http://dartlang.org/root/path/a/b');
-      expect(context.absolute('a', 'b', 'c'),
-          'http://dartlang.org/root/path/a/b/c');
+      expect(context.absolute('a'), 'https://dart.dev/root/path/a');
+      expect(context.absolute('a', 'b'), 'https://dart.dev/root/path/a/b');
+      expect(
+          context.absolute('a', 'b', 'c'), 'https://dart.dev/root/path/a/b/c');
       expect(context.absolute('a', 'b', 'c', 'd'),
-          'http://dartlang.org/root/path/a/b/c/d');
+          'https://dart.dev/root/path/a/b/c/d');
       expect(context.absolute('a', 'b', 'c', 'd', 'e'),
-          'http://dartlang.org/root/path/a/b/c/d/e');
+          'https://dart.dev/root/path/a/b/c/d/e');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f'),
-          'http://dartlang.org/root/path/a/b/c/d/e/f');
+          'https://dart.dev/root/path/a/b/c/d/e/f');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g'),
-          'http://dartlang.org/root/path/a/b/c/d/e/f/g');
+          'https://dart.dev/root/path/a/b/c/d/e/f/g');
     });
 
     test('does not add separator if a part ends in one', () {
       expect(context.absolute('a/', 'b', 'c/', 'd'),
-          'http://dartlang.org/root/path/a/b/c/d');
-      expect(
-          context.absolute(r'a\', 'b'), r'http://dartlang.org/root/path/a\/b');
+          'https://dart.dev/root/path/a/b/c/d');
+      expect(context.absolute(r'a\', 'b'), r'https://dart.dev/root/path/a\/b');
     });
 
     test('ignores parts before an absolute path', () {
-      expect(context.absolute('a', '/b', '/c', 'd'), 'http://dartlang.org/c/d');
+      expect(context.absolute('a', '/b', '/c', 'd'), 'https://dart.dev/c/d');
       expect(context.absolute('a', '/b', 'file:///c', 'd'), 'file:///c/d');
       expect(context.absolute('a', r'c:\b', 'c', 'd'), r'c:\b/c/d');
       expect(context.absolute('a', r'\\b', 'c', 'd'),
-          r'http://dartlang.org/root/path/a/\\b/c/d');
+          r'https://dart.dev/root/path/a/\\b/c/d');
     });
   });
 
@@ -855,16 +834,15 @@ void main() {
 
   group('fromUri', () {
     test('with a URI', () {
-      expect(context.fromUri(Uri.parse('http://dartlang.org/path/to/foo')),
-          'http://dartlang.org/path/to/foo');
-      expect(context.fromUri(Uri.parse('http://dartlang.org/path/to/foo/')),
-          'http://dartlang.org/path/to/foo/');
+      expect(context.fromUri(Uri.parse('https://dart.dev/path/to/foo')),
+          'https://dart.dev/path/to/foo');
+      expect(context.fromUri(Uri.parse('https://dart.dev/path/to/foo/')),
+          'https://dart.dev/path/to/foo/');
       expect(context.fromUri(Uri.parse('file:///path/to/foo')),
           'file:///path/to/foo');
       expect(context.fromUri(Uri.parse('foo/bar')), 'foo/bar');
-      expect(
-          context.fromUri(Uri.parse('http://dartlang.org/path/to/foo%23bar')),
-          'http://dartlang.org/path/to/foo%23bar');
+      expect(context.fromUri(Uri.parse('https://dart.dev/path/to/foo%23bar')),
+          'https://dart.dev/path/to/foo%23bar');
       // Since the resulting "path" is also a URL, special characters should
       // remain percent-encoded in the result.
       expect(context.fromUri(Uri.parse('_%7B_%7D_%60_%5E_%20_%22_%25_')),
@@ -872,22 +850,22 @@ void main() {
     });
 
     test('with a string', () {
-      expect(context.fromUri('http://dartlang.org/path/to/foo'),
-          'http://dartlang.org/path/to/foo');
+      expect(context.fromUri('https://dart.dev/path/to/foo'),
+          'https://dart.dev/path/to/foo');
     });
   });
 
   test('toUri', () {
-    expect(context.toUri('http://dartlang.org/path/to/foo'),
-        Uri.parse('http://dartlang.org/path/to/foo'));
-    expect(context.toUri('http://dartlang.org/path/to/foo/'),
-        Uri.parse('http://dartlang.org/path/to/foo/'));
+    expect(context.toUri('https://dart.dev/path/to/foo'),
+        Uri.parse('https://dart.dev/path/to/foo'));
+    expect(context.toUri('https://dart.dev/path/to/foo/'),
+        Uri.parse('https://dart.dev/path/to/foo/'));
     expect(context.toUri('path/to/foo/'), Uri.parse('path/to/foo/'));
     expect(
         context.toUri('file:///path/to/foo'), Uri.parse('file:///path/to/foo'));
     expect(context.toUri('foo/bar'), Uri.parse('foo/bar'));
-    expect(context.toUri('http://dartlang.org/path/to/foo%23bar'),
-        Uri.parse('http://dartlang.org/path/to/foo%23bar'));
+    expect(context.toUri('https://dart.dev/path/to/foo%23bar'),
+        Uri.parse('https://dart.dev/path/to/foo%23bar'));
     // Since the input path is also a URI, special characters should already
     // be percent encoded there too.
     expect(context.toUri(r'http://foo.com/_%7B_%7D_%60_%5E_%20_%22_%25_'),
@@ -903,13 +881,13 @@ void main() {
     });
 
     test('with an http: URI', () {
-      expect(context.prettyUri('http://dartlang.org/root/path/a/b'), 'a/b');
-      expect(context.prettyUri('http://dartlang.org/root/path/a/../b'), 'b');
-      expect(context.prettyUri('http://dartlang.org/other/path/a/b'),
-          'http://dartlang.org/other/path/a/b');
-      expect(context.prettyUri('http://pub.dartlang.org/root/path'),
-          'http://pub.dartlang.org/root/path');
-      expect(context.prettyUri('http://dartlang.org/root/other'), '../other');
+      expect(context.prettyUri('https://dart.dev/root/path/a/b'), 'a/b');
+      expect(context.prettyUri('https://dart.dev/root/path/a/../b'), 'b');
+      expect(context.prettyUri('https://dart.dev/other/path/a/b'),
+          'https://dart.dev/other/path/a/b');
+      expect(context.prettyUri('http://psub.dart.dev/root/path'),
+          'http://psub.dart.dev/root/path');
+      expect(context.prettyUri('https://dart.dev/root/other'), '../other');
     });
 
     test('with a relative URI', () {

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -734,7 +734,7 @@ void main() {
       expect(context.fromUri(Uri.parse('_%7B_%7D_%60_%5E_%20_%22_%25_')),
           r'_{_}_`_^_ _"_%_');
       expect(context.fromUri(Uri.parse('/foo')), r'\foo');
-      expect(() => context.fromUri(Uri.parse('http://dartlang.org')),
+      expect(() => context.fromUri(Uri.parse('https://dart.dev')),
           throwsArgumentError);
     });
 
@@ -776,8 +776,7 @@ void main() {
     });
 
     test('with an http: URI', () {
-      expect(context.prettyUri('http://dartlang.org/a/b'),
-          'http://dartlang.org/a/b');
+      expect(context.prettyUri('https://dart.dev/a/b'), 'https://dart.dev/a/b');
     });
 
     test('with a relative URI', () {


### PR DESCRIPTION
Drop section on installing from library level doc comment - it isn't
useful enough there, and it had some outdated links.

Replace `http://dartlang.org` with `https://dart.dev` everywhere.

Add a browser example to the doc comment for `context.split` for
consistency with the comment on `p.split`.

Switch some doc comments to use single quotes and avoid `new`.