### PR TITLE
Fix a failing test on mac

### DIFF
--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -56,7 +56,9 @@ void main() {
       } finally {
         io.Directory.current = dir;
       }
-    });
+    },
+        //TODO: Figure out why this is failing on windows and fix!
+        skip: io.Platform.isWindows ? 'Untriaged failure on Windows' : false);
   });
 
   test('registers changes to the working directory', () {

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -43,7 +43,7 @@ void main() {
       final dir = io.Directory.current.path;
       try {
         final temp = io.Directory.systemTemp.createTempSync('path_test');
-        final tempPath = temp.path;
+        final tempPath = temp.resolveSymbolicLinksSync();
         io.Directory.current = temp;
 
         // Call "current" once so that it can be cached.
@@ -56,11 +56,7 @@ void main() {
       } finally {
         io.Directory.current = dir;
       }
-    },
-        //TODO(kevmoo): figure out why this is failing on windows/mac and fix!
-        skip: (io.Platform.isWindows || io.Platform.isMacOS)
-            ? 'Untriaged failure on Mac and Windows'
-            : null);
+    });
   });
 
   test('registers changes to the working directory', () {


### PR DESCRIPTION
`/var` is a symlink to `/private/var`, and when setting
`Directory.current` symlinks are resolved. Explicitly resolve symlinks
to find the canonical path to the newly created temp directory.