### PR TITLE
Document that absolute does not normalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.7.1-dev
+
 ## 1.7.0
 
 * Add support for multiple extension in `context.extension()`.

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -109,10 +109,13 @@ String _current;
 /// and `/` on other platforms (including the browser).
 String get separator => context.separator;
 
-/// Creates a new path by appending the given path parts to [current].
+/// Returns a new path with the given path parts appended to [current].
+///
 /// Equivalent to [join()] with [current] as the first argument. Example:
 ///
 ///     p.absolute('path', 'to/foo'); // -> '/your/current/dir/path/to/foo'
+///
+/// Does not [normalize] or [cananicalize] paths.
 String absolute(String part1,
         [String part2,
         String part3,

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -65,13 +65,15 @@ class Context {
   /// this is `/`. On Windows, it's `\`.
   String get separator => style.separator;
 
-  /// Creates a new path by appending the given path parts to [current].
+  /// Returns a new path with the given path parts appended to [current].
+  ///
   /// Equivalent to [join()] with [current] as the first argument. Example:
   ///
   ///     var context = Context(current: '/root');
   ///     context.absolute('path', 'to', 'foo'); // -> '/root/path/to/foo'
   ///
-  /// If [current] isn't absolute, this won't return an absolute path.
+  /// If [current] isn't absolute, this won't return an absolute path. Does not
+  /// [normalize] or [cananicalize] paths.
   String absolute(String part1,
       [String part2,
       String part3,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.7.0
+version: 1.7.1-dev
 
 description: >-
   A string-based path manipulation library. All of the path operations you know


### PR DESCRIPTION
Closes dart-lang/core#526

Add a sentences indicating that an absolute path is not guaranteed to be
canonical or normalized. Add a blank line following the header sentence
and change the first word to "Returns" to improve doc style.