### PR TITLE
Enable and fix comment_references lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,7 @@ linter:
     - await_only_futures
     - camel_case_types
     - cancel_subscriptions
+    - comment_references
     - constant_identifier_names
     - control_flow_in_finally
     - directives_ordering

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -115,7 +115,7 @@ String get separator => context.separator;
 ///
 ///     p.absolute('path', 'to/foo'); // -> '/your/current/dir/path/to/foo'
 ///
-/// Does not [normalize] or [cananicalize] paths.
+/// Does not [normalize] or [canonicalize] paths.
 String absolute(String part1,
         [String part2,
         String part3,

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -315,7 +315,7 @@ List<String> split(String path) => context.split(path);
 /// Note that this does not resolve symlinks.
 ///
 /// If you want a map that uses path keys, it's probably more efficient to
-/// pass [equals] and [hash] to [new HashMap] than it is to canonicalize every
+/// pass [equals] and [hash] to [new HashMap()] than it is to canonicalize every
 /// key.
 String canonicalize(String path) => context.canonicalize(path);
 
@@ -324,7 +324,7 @@ String canonicalize(String path) => context.canonicalize(path);
 ///
 /// Note that this is *not* guaranteed to return the same result for two
 /// equivalent input paths. For that, see [canonicalize]. Or, if you're using
-/// paths as map keys, pass [equals] and [hash] to [new HashMap].
+/// paths as map keys, pass [equals] and [hash] to [new HashMap()].
 ///
 ///     p.normalize('path/./to/..//file.text'); // -> 'path/file.txt'
 String normalize(String path) => context.normalize(path);

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -314,9 +314,9 @@ List<String> split(String path) => context.split(path);
 ///
 /// Note that this does not resolve symlinks.
 ///
-/// If you want a map that uses path keys, it's probably more efficient to
-/// pass [equals] and [hash] to [new HashMap()] than it is to canonicalize every
-/// key.
+/// If you want a map that uses path keys, it's probably more efficient to use a
+/// Map with [equals] and [hash] specified as the callbacks to use for keys than
+/// it is to canonicalize every key.
 String canonicalize(String path) => context.canonicalize(path);
 
 /// Normalizes [path], simplifying it by handling `..`, and `.`, and
@@ -324,7 +324,7 @@ String canonicalize(String path) => context.canonicalize(path);
 ///
 /// Note that this is *not* guaranteed to return the same result for two
 /// equivalent input paths. For that, see [canonicalize]. Or, if you're using
-/// paths as map keys, pass [equals] and [hash] to [new HashMap()].
+/// paths as map keys use [equals] and [hash] as the key callbacks.
 ///
 ///     p.normalize('path/./to/..//file.text'); // -> 'path/file.txt'
 String normalize(String path) => context.normalize(path);

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -73,7 +73,7 @@ class Context {
   ///     context.absolute('path', 'to', 'foo'); // -> '/root/path/to/foo'
   ///
   /// If [current] isn't absolute, this won't return an absolute path. Does not
-  /// [normalize] or [cananicalize] paths.
+  /// [normalize] or [canonicalize] paths.
   String absolute(String part1,
       [String part2,
       String part3,
@@ -339,7 +339,8 @@ class Context {
   /// Note that this does not resolve symlinks.
   ///
   /// If you want a map that uses path keys, it's probably more efficient to
-  /// pass [equals] and [hash] to [new HashMap] than it is to canonicalize every
+  /// pass [equals] and [hash] to [new HashMap()] than it is to canonicalize
+  /// every
   /// key.
   String canonicalize(String path) {
     path = absolute(path);
@@ -355,7 +356,7 @@ class Context {
   ///
   /// Note that this is *not* guaranteed to return the same result for two
   /// equivalent input paths. For that, see [canonicalize]. Or, if you're using
-  /// paths as map keys, pass [equals] and [hash] to [new HashMap].
+  /// paths as map keys, pass [equals] and [hash] to [new HashMap()].
   ///
   ///     context.normalize('path/./to/..//file.text'); // -> 'path/file.txt'
   String normalize(String path) {

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -338,10 +338,9 @@ class Context {
   ///
   /// Note that this does not resolve symlinks.
   ///
-  /// If you want a map that uses path keys, it's probably more efficient to
-  /// pass [equals] and [hash] to [new HashMap()] than it is to canonicalize
-  /// every
-  /// key.
+  /// If you want a map that uses path keys, it's probably more efficient to use
+  /// a Map with [equals] and [hash] specified as the callbacks to use for keys
+  /// than it is to canonicalize every key.
   String canonicalize(String path) {
     path = absolute(path);
     if (style != Style.windows && !_needsNormalization(path)) return path;
@@ -356,7 +355,7 @@ class Context {
   ///
   /// Note that this is *not* guaranteed to return the same result for two
   /// equivalent input paths. For that, see [canonicalize]. Or, if you're using
-  /// paths as map keys, pass [equals] and [hash] to [new HashMap()].
+  /// paths as map keys use [equals] and [hash] as the key callbacks.
   ///
   ///     context.normalize('path/./to/..//file.text'); // -> 'path/file.txt'
   String normalize(String path) {

--- a/lib/src/internal_style.dart
+++ b/lib/src/internal_style.dart
@@ -58,7 +58,7 @@ abstract class InternalStyle extends Style {
   @override
   String pathFromUri(Uri uri);
 
-  /// Returns the URI that represents the relative path made of [parts].
+  /// Returns the URI that represents a relative path.
   @override
   Uri relativePathToUri(String path) {
     final segments = context.split(path);

--- a/lib/src/parsed_path.dart
+++ b/lib/src/parsed_path.dart
@@ -17,7 +17,7 @@ class ParsedPath {
 
   /// Whether this path is root-relative.
   ///
-  /// See [Context.isRootRelative].
+  /// See `Context.isRootRelative`.
   bool isRootRelative;
 
   /// The path-separated parts of the path. All but the last will be

--- a/lib/src/path_map.dart
+++ b/lib/src/path_map.dart
@@ -6,7 +6,7 @@ import 'dart:collection';
 
 import '../path.dart' as p;
 
-/// A map whose keys are paths, compared using [equals] and [hash].
+/// A map whose keys are paths, compared using [p.equals] and [p.hash].
 class PathMap<V> extends MapView<String, V> {
   /// Creates an empty [PathMap] whose keys are compared using `context.equals`
   /// and `context.hash`.

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -6,7 +6,7 @@ import 'dart:collection';
 
 import '../path.dart' as p;
 
-/// A set containing paths, compared using [equals] and [hash].
+/// A set containing paths, compared using [p.equals] and [p.hash].
 class PathSet extends IterableBase<String> implements Set<String> {
   /// The set to which we forward implementation methods.
   final Set<String> _inner;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -5,7 +5,7 @@
 import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
 
-/// A matcher for a closure that throws a [path.PathException].
+/// A matcher for a closure that throws a [p.PathException].
 final throwsPathException = throwsA(const TypeMatcher<p.PathException>());
 
 void expectEquals(p.Context context, String path1, String path2) {


### PR DESCRIPTION
Fixes typos from #80 along with other references that were not
working in the dart doc.