### PR TITLE
Update for the 2.10 SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
 homepage: https://github.com/dart-lang/path
 
 environment:
- sdk: '>=2.9.0-18.0 <2.9.0'
+ sdk: '>=2.10.0-0 <2.10.0'
 
 dev_dependencies:
   pedantic: ^1.0.0
@@ -20,76 +20,51 @@ dev_dependencies:
 
 dependency_overrides:
   async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
+    git: git://github.com/dart-lang/async.git
   boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
+    git: git://github.com/dart-lang/boolean_selector.git
   charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
-  collection: 1.15.0-nullsafety
+    git: git://github.com/dart-lang/charcode.git
+  collection:
+    git: git://github.com/dart-lang/collection.git
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
-      ref: master
       path: pkg/js
   matcher:
+    git: git://github.com/dart-lang/matcher.git
+  meta:
     git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta: 1.3.0-nullsafety
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/meta
+      ref: 2-10-pkgs
   pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pedantic.git
   pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pool.git
   source_maps:
-    git:
-      url: git://github.com/dart-lang/source_maps.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_maps.git
   source_map_stack_trace:
-    git:
-      url: git://github.com/dart-lang/source_map_stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_map_stack_trace.git
   source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_span.git
   stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stack_trace.git
   stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stream_channel.git
   string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
+    git: git://github.com/dart-lang/string_scanner.git
   term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_api
   test_core:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_core
   test:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test


### PR DESCRIPTION
Bump the min SDK to `2.10.0-0` since the `2.10` SDK no longer allows
null safety experiment with `2.9` language version.

Move to the master branch for git deps where the package has the null
safety migration on master allowing the 2.10 SDK.

Move from some published packages back to git deps.