### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.0-nullsafety.1
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 1.8.0-nullsafety
 
 * Migrate to null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.0-nullsafety
+version: 1.8.0-nullsafety.1
 
 description: >-
   A string-based path manipulation library. All of the path operations you know
@@ -9,7 +9,7 @@ homepage: https://github.com/dart-lang/path
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.