### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.8.0-nullsafety.3
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 ## 1.8.0-nullsafety.2
 
 * Allow prerelease versions of the 2.12 sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.0-nullsafety.2
+version: 1.8.0-nullsafety.3
 
 description: >-
   A string-based path manipulation library. All of the path operations you know
@@ -8,8 +8,7 @@ description: >-
 homepage: https://github.com/dart-lang/path
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.