### PR TITLE
Make PathSet non-nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.0-nullsafety.4
+
+* Make `PathSet` a `Set<String>` rather than a `Set<String?>`.
+
 ## 1.8.0-nullsafety.3
 
 * Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Make `PathSet` a `Set<String>` rather than a `Set<String?>`.
 
+* Make `PathMap` a `Map<String, V>` rather than a `Map<String?, V>`.
+
 ## 1.8.0-nullsafety.3
 
 * Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release

--- a/lib/src/path_map.dart
+++ b/lib/src/path_map.dart
@@ -7,7 +7,7 @@ import 'dart:collection';
 import '../path.dart' as p;
 
 /// A map whose keys are paths, compared using [p.equals] and [p.hash].
-class PathMap<V> extends MapView<String?, V> {
+class PathMap<V> extends MapView<String, V> {
   /// Creates an empty [PathMap] whose keys are compared using `context.equals`
   /// and `context.hash`.
   ///
@@ -24,15 +24,11 @@ class PathMap<V> extends MapView<String?, V> {
       : super(_create(context)..addAll(other));
 
   /// Creates a map that uses [context] for equality and hashing.
-  static Map<String?, V> _create<V>(p.Context? context) {
+  static Map<String, V> _create<V>(p.Context? context) {
     context ??= p.context;
     return LinkedHashMap(
-        equals: (path1, path2) {
-          if (path1 == null) return path2 == null;
-          if (path2 == null) return false;
-          return context!.equals(path1, path2);
-        },
-        hashCode: (path) => path == null ? 0 : context!.hash(path),
-        isValidKey: (path) => path is String || path == null);
+        equals: (path1, path2) => context!.equals(path1, path2),
+        hashCode: (path) => context!.hash(path),
+        isValidKey: (path) => path is String);
   }
 }

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -7,9 +7,9 @@ import 'dart:collection';
 import '../path.dart' as p;
 
 /// A set containing paths, compared using [p.equals] and [p.hash].
-class PathSet extends IterableBase<String?> implements Set<String?> {
+class PathSet extends IterableBase<String> implements Set<String> {
   /// The set to which we forward implementation methods.
-  final Set<String?> _inner;
+  final Set<String> _inner;
 
   /// Creates an empty [PathSet] whose contents are compared using
   /// `context.equals` and `context.hash`.
@@ -27,16 +27,12 @@ class PathSet extends IterableBase<String?> implements Set<String?> {
       : _inner = _create(context)..addAll(other);
 
   /// Creates a set that uses [context] for equality and hashing.
-  static Set<String?> _create(p.Context? context) {
+  static Set<String> _create(p.Context? context) {
     context ??= p.context;
     return LinkedHashSet(
-        equals: (path1, path2) {
-          if (path1 == null) return path2 == null;
-          if (path2 == null) return false;
-          return context!.equals(path1, path2);
-        },
-        hashCode: (path) => path == null ? 0 : context!.hash(path),
-        isValidKey: (path) => path is String || path == null);
+        equals: (path1, path2) => context!.equals(path1, path2),
+        hashCode: (path) => context!.hash(path),
+        isValidKey: (path) => path is String);
   }
 
   // Normally we'd use DelegatingSetView from the collection package to
@@ -44,16 +40,16 @@ class PathSet extends IterableBase<String?> implements Set<String?> {
   // it's so widely used that even brief version skew can be very painful.
 
   @override
-  Iterator<String?> get iterator => _inner.iterator;
+  Iterator<String> get iterator => _inner.iterator;
 
   @override
   int get length => _inner.length;
 
   @override
-  bool add(String? value) => _inner.add(value);
+  bool add(String value) => _inner.add(value);
 
   @override
-  void addAll(Iterable<String?> elements) => _inner.addAll(elements);
+  void addAll(Iterable<String> elements) => _inner.addAll(elements);
 
   @override
   Set<T> cast<T>() => _inner.cast<T>();
@@ -68,10 +64,10 @@ class PathSet extends IterableBase<String?> implements Set<String?> {
   bool containsAll(Iterable<Object?> other) => _inner.containsAll(other);
 
   @override
-  Set<String?> difference(Set<Object?> other) => _inner.difference(other);
+  Set<String> difference(Set<Object?> other) => _inner.difference(other);
 
   @override
-  Set<String?> intersection(Set<Object?> other) => _inner.intersection(other);
+  Set<String> intersection(Set<Object?> other) => _inner.intersection(other);
 
   @override
   String? lookup(Object? element) => _inner.lookup(element);
@@ -83,17 +79,17 @@ class PathSet extends IterableBase<String?> implements Set<String?> {
   void removeAll(Iterable<Object?> elements) => _inner.removeAll(elements);
 
   @override
-  void removeWhere(bool Function(String?) test) => _inner.removeWhere(test);
+  void removeWhere(bool Function(String) test) => _inner.removeWhere(test);
 
   @override
   void retainAll(Iterable<Object?> elements) => _inner.retainAll(elements);
 
   @override
-  void retainWhere(bool Function(String?) test) => _inner.retainWhere(test);
+  void retainWhere(bool Function(String) test) => _inner.retainWhere(test);
 
   @override
-  Set<String?> union(Set<String?> other) => _inner.union(other);
+  Set<String> union(Set<String> other) => _inner.union(other);
 
   @override
-  Set<String?> toSet() => _inner.toSet();
+  Set<String> toSet() => _inner.toSet();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.0-nullsafety.3
+version: 1.8.0-nullsafety.4
 
 description: >-
   A string-based path manipulation library. All of the path operations you know

--- a/test/path_map_test.dart
+++ b/test/path_map_test.dart
@@ -24,14 +24,6 @@ void main() {
       expect(map, containsPair('foo', 2));
       expect(map, containsPair(absolute('foo'), 2));
     });
-
-    test('two nulls', () {
-      final map = PathMap<int>();
-      map[null] = 1;
-      map[null] = 2;
-      expect(map, hasLength(1));
-      expect(map, containsPair(null, 2));
-    });
   });
 
   group('considers unequal', () {
@@ -42,15 +34,6 @@ void main() {
       expect(map, hasLength(2));
       expect(map, containsPair('foo', 1));
       expect(map, containsPair('bar', 2));
-    });
-
-    test('a path and null', () {
-      final map = PathMap<int>();
-      map['foo'] = 1;
-      map[null] = 2;
-      expect(map, hasLength(2));
-      expect(map, containsPair('foo', 1));
-      expect(map, containsPair(null, 2));
     });
   });
 

--- a/test/path_set_test.dart
+++ b/test/path_set_test.dart
@@ -24,14 +24,6 @@ void main() {
       expect(set, contains('foo'));
       expect(set, contains(absolute('foo')));
     });
-
-    test('two nulls', () {
-      final set = PathSet();
-      expect(set.add(null), isTrue);
-      expect(set.add(null), isFalse);
-      expect(set, hasLength(1));
-      expect(set, contains(null));
-    });
   });
 
   group('considers unequal', () {
@@ -42,15 +34,6 @@ void main() {
       expect(set, hasLength(2));
       expect(set, contains('foo'));
       expect(set, contains('bar'));
-    });
-
-    test('a path and null', () {
-      final set = PathSet();
-      expect(set.add('foo'), isTrue);
-      expect(set.add(null), isTrue);
-      expect(set, hasLength(2));
-      expect(set, contains('foo'));
-      expect(set, contains(null));
     });
   });
 


### PR DESCRIPTION
The only reason I originally wrote this to gracefully handle nulls was
because it was difficult to statically guarantee that no nulls would
sneak in. Now that it's possible to statically declare that, there's
no real use-case for having this be a Set<String?>.