### PR TITLE
Drop unnecessary constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.8.1-dev
+
 ## 1.8.0
 
 * Stable release for null safety.

--- a/lib/src/style/posix.dart
+++ b/lib/src/style/posix.dart
@@ -8,8 +8,6 @@ import '../parsed_path.dart';
 
 /// The style for POSIX paths.
 class PosixStyle extends InternalStyle {
-  PosixStyle();
-
   @override
   final name = 'posix';
   @override

--- a/lib/src/style/url.dart
+++ b/lib/src/style/url.dart
@@ -8,8 +8,6 @@ import '../utils.dart';
 
 /// The style for URL paths.
 class UrlStyle extends InternalStyle {
-  UrlStyle();
-
   @override
   final name = 'url';
   @override

--- a/lib/src/style/windows.dart
+++ b/lib/src/style/windows.dart
@@ -13,8 +13,6 @@ const _asciiCaseBit = 0x20;
 
 /// The style for Windows paths.
 class WindowsStyle extends InternalStyle {
-  WindowsStyle();
-
   @override
   final name = 'windows';
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.0
+version: 1.8.1-dev
 
 description: >-
   A string-based path manipulation library. All of the path operations you know


### PR DESCRIPTION
When a class has no other constructors it is unnecessary and
non-idiomatic to define the default empty constructor.