### PR TITLE
added tildeExpansion

### DIFF
--- a/lib/path.dart
+++ b/lib/path.dart
@@ -459,3 +459,8 @@ Uri toUri(String path) => context.toUri(path);
 ///     p.prettyUri('https://dart.dev/root/path/a/b.dart'); // -> r'a/b.dart'
 ///     p.prettyUri('file:///root/path'); // -> 'file:///root/path'
 String prettyUri(uri) => context.prettyUri(uri);
+/// Tilde expansion [path], find an replace ~[user] wherever possible and replace by home path.
+///
+///     context.tiledExpansion('~/path/'); // -> '/home/user/path'
+///     posix doesn't say what happens when the user is not found, here the original path is returned
+String tildeExpansion(String path) => context.tildeExpansion(path);

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -1068,6 +1068,23 @@ class Context {
   }
 
   ParsedPath _parse(String path) => ParsedPath.parse(path, style);
+
+  /// Tilde expansion [path], find an replace ~[user] wherever possible and replace by home path.
+  ///
+  ///     context.tiledExpansion('~/path/'); // -> '/home/user/path'
+  ///     posix doesn't say what happens when the user is not found, here the original path is returned
+  String tildeExpansion(String path) {
+    if (!_needsTildeExpansion(path)) return path;
+    //final parsed = _parse(path);
+    final parsed = style.tildeExpansion(path);
+    return parsed;
+  }
+  /// Returns whether [path] needs to be tilde expansed.
+  bool _needsTildeExpansion(String path) {
+    if (style == Style.windows) return false;
+    if(path.contains('~')) return true;
+    return false;
+  }
 }
 
 /// Parses argument if it's a [String] or returns it intact if it's a [Uri].

--- a/lib/src/internal_style.dart
+++ b/lib/src/internal_style.dart
@@ -87,4 +87,7 @@ abstract class InternalStyle extends Style {
   int canonicalizeCodeUnit(int codeUnit) => codeUnit;
 
   String canonicalizePart(String part) => part;
+  /// tries to interpret the tilde at the start of the parth and to resolve it into
+  /// a user home path, returns original otherwise
+  String tildeExpansion(String part) => part;
 }

--- a/lib/src/style/posix.dart
+++ b/lib/src/style/posix.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:posix/posix.dart';
+
 import '../characters.dart' as chars;
 import '../internal_style.dart';
 import '../parsed_path.dart';
@@ -70,5 +74,25 @@ class PosixStyle extends InternalStyle {
     }
 
     return Uri(scheme: 'file', pathSegments: parsed.parts);
+  }
+
+  @override
+  String tildeExpansion(String path){
+    if(path.startsWith('~'))
+    {
+      List<String> parts = path.split(separator);
+      if(parts[0] == '~') parts[0] = ((Platform.environment.containsKey('HOME'))?Platform.environment['HOME']:"")!;
+      else {
+        String user = parts[0].replaceAll('~', '');
+        try {
+          parts[0] = getpwnam(user).homePathTo;
+        }
+        catch(e){
+          //print("failed to find user $user");
+        }
+      }
+      path = parts.join(separator);
+    }
+    return path;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,5 @@ environment:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0
+dependencies: 
+  posix: ^3.0.0

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -123,6 +125,8 @@ void main() {
     expect(context.isAbsolute('C:/a'), false);
     expect(context.isAbsolute(r'C:\a'), false);
     expect(context.isAbsolute(r'\\a'), false);
+    expect(context.isAbsolute('~/a'), false);
+    expect(context.isAbsolute('~user/a'), false);
   });
 
   test('isRelative', () {
@@ -139,6 +143,8 @@ void main() {
     expect(context.isRelative('C:/a'), true);
     expect(context.isRelative(r'C:\a'), true);
     expect(context.isRelative(r'\\a'), true);
+    expect(context.isRelative('~/a'), true);
+    expect(context.isRelative('~user/a'), true);
   });
 
   group('join', () {
@@ -616,5 +622,16 @@ void main() {
     test('with a Uri object', () {
       expect(context.prettyUri(Uri.parse('a/b')), 'a/b');
     });
+  });
+  group('tilde', () {
+    String homedir = ((Platform.environment.containsKey('HOME'))?Platform.environment['HOME']:"")!;
+    String usern = ((Platform.environment.containsKey('USER'))?Platform.environment['USER']:"")!;
+    test('simple cases', () {
+      expect(context.tildeExpansion('~').toString(), homedir);
+      expect(context.tildeExpansion('~/a/b.txt').toString(), '$homedir/a/b.txt');
+      expect(context.tildeExpansion('~user').toString(), '~user');
+      expect(context.tildeExpansion('~$usern/a/b.txt').toString(), '$homedir/a/b.txt');
+    });
+
   });
 }


### PR DESCRIPTION
i opened an issue with the fact that path is not posix compliant since it ignores ~ as a path element...
since i need that compliance (and i think that all linux dart users at some point need this) 
i added the tilde expansion and added it to style, and tests

tests run all without a hitch,  i had to add the posix lib for the getpwnam system access
if you could include this in mainline that would be kind, and if you are happy with the code please kindly activate it in the normalize call