### PR TITLE
enable the avoid_dynamic_calls lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.2-dev
+
+* Enable the `avoid_dynamic_calls` lint.
+
 ## 1.8.1
 
 * Don't crash when an empty string is passed to `toUri()`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,7 @@ analyzer:
 linter:
   rules:
     - avoid_catching_errors
+    - avoid_dynamic_calls
     - avoid_function_literals_in_foreach_calls
     - avoid_private_typedef_functions
     - avoid_renaming_method_parameters

--- a/benchmark/benchmark.dart
+++ b/benchmark/benchmark.dart
@@ -41,7 +41,7 @@ void main(List<String> args) {
     final context = p.Context(style: style);
     final files = <String>[...genericPaths, ...platformPaths[style]!];
 
-    void benchmark(String name, Function function) {
+    void benchmark(String name, void Function(String) function) {
       runBenchmark('${style.name}-$name', 100000, () {
         for (var file in files) {
           function(file);
@@ -85,7 +85,7 @@ void main(List<String> args) {
   runBenchmark('current', 100000, () => p.current);
 }
 
-void runBenchmark(String name, int count, Function function) {
+void runBenchmark(String name, int count, void Function() function) {
   // If names are passed on the command-line, they select which benchmarks are
   // run.
   if (arguments.isNotEmpty && !arguments.contains(name)) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.1
+version: 1.8.2-dev
 
 description: >-
   A string-based path manipulation library. All of the path operations you know


### PR DESCRIPTION
- enable the `avoid_dynamic_calls` lint
- fixup the existing issues (two minors ones in `benchmark/benchmark.dart`)
