### PR TITLE
Supports more arguments in path.join API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.3
+
+* Support up to 16 arguments in join function and up to 15 arguments in absolute function. 
+
 ## 1.8.2
 
 * Enable the `avoid_dynamic_calls` lint.

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -131,7 +131,8 @@ String absolute(String part1,
         String? part13,
         String? part14,
         String? part15]) =>
-    context.absolute(part1, part2, part3, part4, part5, part6, part7, part8, part9, part10, part11, part12, part13, part14, part15);
+    context.absolute(part1, part2, part3, part4, part5, part6, part7, part8,
+        part9, part10, part11, part12, part13, part14, part15);
 
 /// Gets the part of [path] after the last separator.
 ///

--- a/lib/path.dart
+++ b/lib/path.dart
@@ -122,8 +122,16 @@ String absolute(String part1,
         String? part4,
         String? part5,
         String? part6,
-        String? part7]) =>
-    context.absolute(part1, part2, part3, part4, part5, part6, part7);
+        String? part7,
+        String? part8,
+        String? part9,
+        String? part10,
+        String? part11,
+        String? part12,
+        String? part13,
+        String? part14,
+        String? part15]) =>
+    context.absolute(part1, part2, part3, part4, part5, part6, part7, part8, part9, part10, part11, part12, part13, part14, part15);
 
 /// Gets the part of [path] after the last separator.
 ///
@@ -261,8 +269,17 @@ String join(String part1,
         String? part5,
         String? part6,
         String? part7,
-        String? part8]) =>
-    context.join(part1, part2, part3, part4, part5, part6, part7, part8);
+        String? part8,
+        String? part9,
+        String? part10,
+        String? part11,
+        String? part12,
+        String? part13,
+        String? part14,
+        String? part15,
+        String? part16]) =>
+    context.join(part1, part2, part3, part4, part5, part6, part7, part8, part9,
+        part10, part11, part12, part13, part14, part15, part16);
 
 /// Joins the given path parts into a single path using the current platform's
 /// [separator]. Example:

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -113,7 +113,8 @@ class Context {
       return part1;
     }
 
-    return join(current, part1, part2, part3, part4, part5, part6, part7);
+    return join(current, part1, part2, part3, part4, part5, part6, part7, part8,
+        part9, part10, part11, part12, part13, part14, part15);
   }
 
   /// Gets the part of [path] after the last separator on the context's

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -89,8 +89,23 @@ class Context {
       String? part13,
       String? part14,
       String? part15]) {
-    _validateArgList(
-        'absolute', [part1, part2, part3, part4, part5, part6, part7, part8, part9, part10, part11, part12, part13, part14, part15]);
+    _validateArgList('absolute', [
+      part1,
+      part2,
+      part3,
+      part4,
+      part5,
+      part6,
+      part7,
+      part8,
+      part9,
+      part10,
+      part11,
+      part12,
+      part13,
+      part14,
+      part15
+    ]);
 
     // If there's a single absolute path, just return it. This is a lot faster
     // for the common case of `p.absolute(path)`.

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -80,9 +80,17 @@ class Context {
       String? part4,
       String? part5,
       String? part6,
-      String? part7]) {
+      String? part7,
+      String? part8,
+      String? part9,
+      String? part10,
+      String? part11,
+      String? part12,
+      String? part13,
+      String? part14,
+      String? part15]) {
     _validateArgList(
-        'absolute', [part1, part2, part3, part4, part5, part6, part7]);
+        'absolute', [part1, part2, part3, part4, part5, part6, part7, part8, part9, part10, part11, part12, part13, part14, part15]);
 
     // If there's a single absolute path, just return it. This is a lot faster
     // for the common case of `p.absolute(path)`.
@@ -228,7 +236,15 @@ class Context {
       String? part5,
       String? part6,
       String? part7,
-      String? part8]) {
+      String? part8,
+      String? part9,
+      String? part10,
+      String? part11,
+      String? part12,
+      String? part13,
+      String? part14,
+      String? part15,
+      String? part16]) {
     final parts = <String?>[
       part1,
       part2,
@@ -237,7 +253,15 @@ class Context {
       part5,
       part6,
       part7,
-      part8
+      part8,
+      part9,
+      part10,
+      part11,
+      part12,
+      part13,
+      part14,
+      part15,
+      part16,
     ];
     _validateArgList('join', parts);
     return joinAll(parts.whereType<String>());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.8.2
+version: 1.8.3
 description: >-
   A string-based path manipulation library. All of the path operations you know
   and love, with solid support for Windows, POSIX (Linux and Mac OS X), and the

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -142,7 +142,7 @@ void main() {
   });
 
   group('join', () {
-    test('allows up to eight parts', () {
+    test('allows up to sixteen parts', () {
       expect(context.join('a'), 'a');
       expect(context.join('a', 'b'), 'a/b');
       expect(context.join('a', 'b', 'c'), 'a/b/c');
@@ -152,6 +152,22 @@ void main() {
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g'), 'a/b/c/d/e/f/g');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
           'a/b/c/d/e/f/g/h');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          'a/b/c/d/e/f/g/h/i');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          'a/b/c/d/e/f/g/h/i/j');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          'a/b/c/d/e/f/g/h/i/j/k');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          'a/b/c/d/e/f/g/h/i/j/k/l');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p');
     });
 
     test('does not add separator if a part ends in one', () {
@@ -193,9 +209,9 @@ void main() {
   });
 
   group('joinAll', () {
-    test('allows more than eight parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']),
-          'a/b/c/d/e/f/g/h/i');
+    test('allows more than sixteen parts', () {
+      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q');
     });
 
     test('does not add separator if a part ends in one', () {
@@ -493,7 +509,7 @@ void main() {
   });
 
   group('absolute', () {
-    test('allows up to seven parts', () {
+    test('allows up to fifteen parts', () {
       expect(context.absolute('a'), '/root/path/a');
       expect(context.absolute('a', 'b'), '/root/path/a/b');
       expect(context.absolute('a', 'b', 'c'), '/root/path/a/b/c');
@@ -503,6 +519,22 @@ void main() {
           '/root/path/a/b/c/d/e/f');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g'),
           '/root/path/a/b/c/d/e/f/g');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
+          '/root/path/a/b/c/d/e/f/g/h');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          '/root/path/a/b/c/d/e/f/g/h/i');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j/k');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j/k/l');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+          '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
     });
 
     test('does not add separator if a part ends in one', () {

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -156,17 +156,28 @@ void main() {
           'a/b/c/d/e/f/g/h/i');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
           'a/b/c/d/e/f/g/h/i/j');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
           'a/b/c/d/e/f/g/h/i/j/k');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
           'a/b/c/d/e/f/g/h/i/j/k/l');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o', 'p'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p');
     });
 
@@ -210,7 +221,26 @@ void main() {
 
   group('joinAll', () {
     test('allows more than sixteen parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+      expect(
+          context.joinAll([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            'f',
+            'g',
+            'h',
+            'i',
+            'j',
+            'k',
+            'l',
+            'm',
+            'n',
+            'o',
+            'p',
+            'q'
+          ]),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q');
     });
 
@@ -525,15 +555,25 @@ void main() {
           '/root/path/a/b/c/d/e/f/g/h/i');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
           '/root/path/a/b/c/d/e/f/g/h/i/j');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
           '/root/path/a/b/c/d/e/f/g/h/i/j/k');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
           '/root/path/a/b/c/d/e/f/g/h/i/j/k/l');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
           '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n'),
           '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n', 'o'),
           '/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
     });
 

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -195,7 +195,7 @@ void main() {
   });
 
   group('join', () {
-    test('allows up to eight parts', () {
+    test('allows up to sixteen parts', () {
       expect(context.join('a'), 'a');
       expect(context.join('a', 'b'), 'a/b');
       expect(context.join('a', 'b', 'c'), 'a/b/c');
@@ -205,6 +205,22 @@ void main() {
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g'), 'a/b/c/d/e/f/g');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
           'a/b/c/d/e/f/g/h');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          'a/b/c/d/e/f/g/h/i');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          'a/b/c/d/e/f/g/h/i/j');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          'a/b/c/d/e/f/g/h/i/j/k');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          'a/b/c/d/e/f/g/h/i/j/k/l');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p');
     });
 
     test('does not add separator if a part ends in one', () {
@@ -285,9 +301,9 @@ void main() {
   });
 
   group('joinAll', () {
-    test('allows more than eight parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']),
-          'a/b/c/d/e/f/g/h/i');
+    test('allows more than sixteen parts', () {
+      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+          'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q');
     });
 
     test('ignores parts before an absolute path', () {
@@ -763,7 +779,7 @@ void main() {
   });
 
   group('absolute', () {
-    test('allows up to seven parts', () {
+    test('allows up to fifteen parts', () {
       expect(context.absolute('a'), 'https://dart.dev/root/path/a');
       expect(context.absolute('a', 'b'), 'https://dart.dev/root/path/a/b');
       expect(
@@ -776,6 +792,22 @@ void main() {
           'https://dart.dev/root/path/a/b/c/d/e/f');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n/o');
     });
 
     test('does not add separator if a part ends in one', () {

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -826,26 +826,28 @@ void main() {
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j/k');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j/k/l');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m');
       expect(
-          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
-              'l', 'm', 'n', 'o'),
-          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n/o');
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n');
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n', 'o'),
+          'https://dart.dev/root/path/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
     });
 
     test('does not add separator if a part ends in one', () {

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -209,17 +209,28 @@ void main() {
           'a/b/c/d/e/f/g/h/i');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
           'a/b/c/d/e/f/g/h/i/j');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
           'a/b/c/d/e/f/g/h/i/j/k');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
           'a/b/c/d/e/f/g/h/i/j/k/l');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o', 'p'),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p');
     });
 
@@ -302,7 +313,26 @@ void main() {
 
   group('joinAll', () {
     test('allows more than sixteen parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+      expect(
+          context.joinAll([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            'f',
+            'g',
+            'h',
+            'i',
+            'j',
+            'k',
+            'l',
+            'm',
+            'n',
+            'o',
+            'p',
+            'q'
+          ]),
           'a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q');
     });
 
@@ -800,13 +830,21 @@ void main() {
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
+              'l', 'm', 'n', 'o'),
           'https://dart.dev/root/path/a/b/c/d/e/f/g/h/j/k/l/m/n/o');
     });
 

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -705,26 +705,28 @@ void main() {
           r'C:\root\path\a\b\c\d\e\f\g\h');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
           r'C:\root\path\a\b\c\d\e\f\g\h\i');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j\k');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j\k');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j\k\l');
       expect(
           context.absolute(
-              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n');
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j\k\l\m');
       expect(
-          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
-              'l', 'm', 'n', 'o'),
-          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n\o');
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j\k\l\m\n');
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+              'k', 'l', 'm', 'n', 'o'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i\j\k\l\m\n\o');
     });
 
     test('does not add separator if a part ends in one', () {

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -219,17 +219,28 @@ void main() {
           r'a\b\c\d\e\f\g\h\i');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
           r'a\b\c\d\e\f\g\h\i\j');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
           r'a\b\c\d\e\f\g\h\i\j\k');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
           r'a\b\c\d\e\f\g\h\i\j\k\l');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+      expect(
+          context.join(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
           r'a\b\c\d\e\f\g\h\i\j\k\l\m');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n'),
           r'a\b\c\d\e\f\g\h\i\j\k\l\m\n');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o'),
           r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o');
-      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+      expect(
+          context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+              'l', 'm', 'n', 'o', 'p'),
           r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p');
     });
 
@@ -275,7 +286,26 @@ void main() {
 
   group('joinAll', () {
     test('allows more than sixteen parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+      expect(
+          context.joinAll([
+            'a',
+            'b',
+            'c',
+            'd',
+            'e',
+            'f',
+            'g',
+            'h',
+            'i',
+            'j',
+            'k',
+            'l',
+            'm',
+            'n',
+            'o',
+            'p',
+            'q'
+          ]),
           r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q');
     });
 
@@ -679,13 +709,21 @@ void main() {
           r'C:\root\path\a\b\c\d\e\f\g\h\j');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
           r'C:\root\path\a\b\c\d\e\f\g\h\j\k');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
           r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
           r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
+      expect(
+          context.absolute(
+              'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
           r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n');
-      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o'),
+      expect(
+          context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k',
+              'l', 'm', 'n', 'o'),
           r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n\o');
     });
 

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -205,7 +205,7 @@ void main() {
   });
 
   group('join', () {
-    test('allows up to eight parts', () {
+    test('allows up to sixteen parts', () {
       expect(context.join('a'), 'a');
       expect(context.join('a', 'b'), r'a\b');
       expect(context.join('a', 'b', 'c'), r'a\b\c');
@@ -215,6 +215,22 @@ void main() {
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g'), r'a\b\c\d\e\f\g');
       expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
           r'a\b\c\d\e\f\g\h');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          r'a\b\c\d\e\f\g\h\i');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'),
+          r'a\b\c\d\e\f\g\h\i\j');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'),
+          r'a\b\c\d\e\f\g\h\i\j\k');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'),
+          r'a\b\c\d\e\f\g\h\i\j\k\l');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'),
+          r'a\b\c\d\e\f\g\h\i\j\k\l\m');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'),
+          r'a\b\c\d\e\f\g\h\i\j\k\l\m\n');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'),
+          r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o');
+      expect(context.join('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'),
+          r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p');
     });
 
     test('does not add separator if a part ends or begins in one', () {
@@ -258,9 +274,9 @@ void main() {
   });
 
   group('joinAll', () {
-    test('allows more than eight parts', () {
-      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']),
-          r'a\b\c\d\e\f\g\h\i');
+    test('allows more than sixteen parts', () {
+      expect(context.joinAll(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q']),
+          r'a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q');
     });
 
     test('does not add separator if a part ends or begins in one', () {
@@ -644,7 +660,7 @@ void main() {
   });
 
   group('absolute', () {
-    test('allows up to seven parts', () {
+    test('allows up to fifteen parts', () {
       expect(context.absolute('a'), r'C:\root\path\a');
       expect(context.absolute('a', 'b'), r'C:\root\path\a\b');
       expect(context.absolute('a', 'b', 'c'), r'C:\root\path\a\b\c');
@@ -655,6 +671,22 @@ void main() {
           r'C:\root\path\a\b\c\d\e\f');
       expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g'),
           r'C:\root\path\a\b\c\d\e\f\g');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'),
+          r'C:\root\path\a\b\c\d\e\f\g\h');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\i');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j\k');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n');
+      expect(context.absolute('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'o'),
+          r'C:\root\path\a\b\c\d\e\f\g\h\j\k\l\m\n\o');
     });
 
     test('does not add separator if a part ends in one', () {


### PR DESCRIPTION
When working on flutter tools, occasionally I need 9-12 parts, and it's a bit annoying to have to break them up. 

Why 16 arguments? 16 should be good enough to cover most cases (based on my experience on tools repo in the past few weeks). I doubt there's a good reason for 8 either (not documented at least), so i just double it to 16. 

