### PR TITLE
fixed mistake in split method doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.8.4-dev
 
 * Require Dart 2.19
+* fix mistake in the split method doc comment
 
 ## 1.8.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.8.4-dev
 
 * Require Dart 2.19
-* fix mistake in the split method doc comment
+* Fixed an issue with the `split` method doc comment.
 
 ## 1.8.3
 

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -356,7 +356,7 @@ class Context {
   ///     // Windows
   ///     context.split(r'C:\path\to\foo'); // -> [r'C:\', 'path', 'to', 'foo']
   ///     context.split(r'\\server\share\path\to\foo');
-  ///       // -> [r'\\server\share', 'foo', 'bar', 'baz']
+  ///       // -> [r'\\server\share', 'path', 'to', 'foo']
   ///
   ///     // Browser
   ///     context.split('https://dart.dev/path/to/foo');


### PR DESCRIPTION
The doc comment of the split method in context.dart showed the wrong result for splitting r'\\server\share\path\to\foo' on windows.