### PR TITLE
rev the version of lints used; prep for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 1.9.0-wip
+## 1.9.0
 
-* Require Dart 3.0
-* Fixed an issue with the `split` method doc comment.
 * Allow percent-encoded colons (`%3a`) in drive letters in `fromUri`.
+* Fixed an issue with the `split` method doc comment.
+* Require Dart 3.0
 
 ## 1.8.3
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,5 @@
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
-analyzer:
-  language:
-    strict-casts: true
-    strict-inference: true
-
 linter:
   rules:
     - avoid_private_typedef_functions

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,7 @@ include: package:dart_flutter_team_lints/analysis_options.yaml
 analyzer:
   language:
     strict-casts: true
+    strict-inference: true
 
 linter:
   rules:
@@ -10,17 +11,12 @@ linter:
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cancel_subscriptions
-    - comment_references
     - join_return_with_assignment
     - missing_whitespace_between_adjacent_strings
     - no_runtimeType_toString
     - package_api_docs
-    - prefer_const_constructors
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_locals
-    - prefer_relative_imports
-    - test_types_in_equals
     - unnecessary_breaks
     - use_string_buffers
-    - use_super_parameters

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: path
-version: 1.9.0-wip
+version: 1.9.0
 description: >-
   A string-based path manipulation library. All of the path operations you know
   and love, with solid support for Windows, POSIX (Linux and Mac OS X), and the
@@ -10,5 +10,5 @@ environment:
   sdk: ^3.0.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.0.0
   test: ^1.16.0

--- a/test/posix_test.dart
+++ b/test/posix_test.dart
@@ -259,7 +259,7 @@ void main() {
 
   group('split', () {
     test('simple cases', () {
-      expect(context.split(''), []);
+      expect(context.split(''), <String>[]);
       expect(context.split('.'), ['.']);
       expect(context.split('..'), ['..']);
       expect(context.split('foo'), equals(['foo']));

--- a/test/url_test.dart
+++ b/test/url_test.dart
@@ -377,7 +377,7 @@ void main() {
 
   group('split', () {
     test('simple cases', () {
-      expect(context.split(''), []);
+      expect(context.split(''), <String>[]);
       expect(context.split('.'), ['.']);
       expect(context.split('..'), ['..']);
       expect(context.split('foo'), equals(['foo']));

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -327,7 +327,7 @@ void main() {
 
   group('split', () {
     test('simple cases', () {
-      expect(context.split(''), []);
+      expect(context.split(''), <String>[]);
       expect(context.split('.'), ['.']);
       expect(context.split('..'), ['..']);
       expect(context.split('foo'), equals(['foo']));


### PR DESCRIPTION
- rev to the latest version of `package:dart_flutter_team_lints`
- prep for publishing to capture recent unpublished work

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
