### PR TITLE
Add `topics` to  `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,12 +6,12 @@ description: >-
   web.
 repository: https://github.com/dart-lang/path
 
+topics:
+ - file-system
+
 environment:
   sdk: ^3.0.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
   test: ^1.16.0
-
-topics:
- - file-system

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,6 @@ environment:
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
   test: ^1.16.0
+
+topics:
+ - file-system


### PR DESCRIPTION
Topics help users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:
```
topics:
 - my-topic
 - some-other-topic
```
See also: https://dart.dev/tools/pub/pubspec#topics